### PR TITLE
Feature var order option

### DIFF
--- a/src/context/context.c
+++ b/src/context/context.c
@@ -5427,6 +5427,7 @@ void delete_context(context_t *ctx) {
   }
 
   delete_gate_manager(&ctx->gate_manager);
+  /* delete_mcsat_options(&ctx->mcsat_options); // if used then the same memory is freed twice */ 
 
   delete_intern_tbl(&ctx->intern);
   delete_ivector(&ctx->top_eqs);

--- a/src/context/context.c
+++ b/src/context/context.c
@@ -5427,7 +5427,6 @@ void delete_context(context_t *ctx) {
   }
 
   delete_gate_manager(&ctx->gate_manager);
-  /* delete_mcsat_options(&ctx->mcsat_options); // if used then the same memory is freed twice */ 
 
   delete_intern_tbl(&ctx->intern);
   delete_ivector(&ctx->top_eqs);

--- a/src/frontend/common/parameters.c
+++ b/src/frontend/common/parameters.c
@@ -362,6 +362,7 @@ bool param_val_to_factor(const char *name, const param_val_t *v, double *value, 
 bool param_val_to_terms(const char *name, const param_val_t *v, ivector_t **value, char **reason) {
   if (v->tag == PARAM_VAL_TERMS) {
     *value = v->val.terms;
+    return true;
   }
   *reason = "list of variables required";
   return false;

--- a/src/frontend/common/parameters.c
+++ b/src/frontend/common/parameters.c
@@ -71,6 +71,7 @@ static const char * const param_names[NUM_PARAMETERS] = {
   "mcsat-nra-bound-min",
   "mcsat-nra-mgcd",
   "mcsat-nra-nlsat",
+  "mcsat-var-order",
   "optimistic-fcheck",
   "prop-threshold",
   "r-factor",
@@ -126,6 +127,7 @@ static const yices_param_t param_code[NUM_PARAMETERS] = {
   PARAM_MCSAT_NRA_BOUND_MIN,
   PARAM_MCSAT_NRA_MGCD,
   PARAM_MCSAT_NRA_NLSAT,
+  PARAM_MCSAT_VAR_ORDER,
   PARAM_OPTIMISTIC_FCHECK,
   PARAM_PROP_THRESHOLD,
   PARAM_R_FACTOR,
@@ -356,8 +358,14 @@ bool param_val_to_factor(const char *name, const param_val_t *v, double *value, 
   return false;
 }
 
-
-
+// terms
+bool param_val_to_terms(const char *name, const param_val_t *v, ivector_t **value, char **reason) {
+  if (v->tag == PARAM_VAL_TERMS) {
+    *value = v->val.terms;
+  }
+  *reason = "list of variables required";
+  return false;
+}
 
 /*
  * Special case: branching mode

--- a/src/frontend/common/parameters.h
+++ b/src/frontend/common/parameters.h
@@ -26,6 +26,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "utils/int_vectors.h"
 #include "api/search_parameters.h"
 #include "exists_forall/ef_parameters.h"
 
@@ -101,6 +102,7 @@ typedef enum yices_param {
   PARAM_MCSAT_NRA_BOUND_MIN,
   PARAM_MCSAT_NRA_BOUND_MAX,
   PARAM_MCSAT_BV_VAR_SIZE,
+  PARAM_MCSAT_VAR_ORDER,
   // error
   PARAM_UNKNOWN
 } yices_param_t;
@@ -119,6 +121,7 @@ typedef enum param_val_enum {
   PARAM_VAL_TRUE,
   PARAM_VAL_RATIONAL,
   PARAM_VAL_SYMBOL,
+  PARAM_VAL_TERMS,
   PARAM_VAL_ERROR,
 } param_val_enum_t;
 
@@ -127,6 +130,7 @@ typedef struct param_val_s {
   union {
     rational_t *rational;
     char *symbol;
+    ivector_t *terms;
   } val;
 } param_val_t;
 
@@ -174,6 +178,7 @@ extern bool param_val_to_float(const char *name, const param_val_t *v, double *v
 extern bool param_val_to_posfloat(const char *name, const param_val_t *v, double *value, char **reason);
 extern bool param_val_to_ratio(const char *name, const param_val_t *v, double *value, char **reason);
 extern bool param_val_to_factor(const char *name, const param_val_t *v, double *value, char **reason);
+extern bool param_val_to_terms(const char *name, const param_val_t *v, ivector_t **value, char **reason);
 
 /*
  * Special case: branching mode

--- a/src/frontend/smt2/smt2_commands.c
+++ b/src/frontend/smt2/smt2_commands.c
@@ -2150,6 +2150,10 @@ static void print_boolean_value(bool value) {
   print_symbol_value(string_bool[value]);
 }
 
+static void print_int32_value(uint32_t value) {
+  print_out("%"PRIi32"\n", value);
+}
+
 static void print_uint32_value(uint32_t value) {
   print_out("%"PRIu32"\n", value);
 }
@@ -4442,6 +4446,26 @@ static bool yices_get_option(const smt2_globals_t *g, yices_param_t p) {
 
   case PARAM_EF_MAX_ITERS:
     print_uint32_value(g->ef_client.ef_parameters.max_iters);
+    break;
+
+  case PARAM_MCSAT_NRA_BOUND:
+    print_boolean_value(g->mcsat_options.nra_bound);
+    break;
+
+  case PARAM_MCSAT_NRA_BOUND_MAX:
+    print_int32_value(g->mcsat_options.nra_bound_max);
+    break;
+
+  case PARAM_MCSAT_NRA_BOUND_MIN:
+    print_int32_value(g->mcsat_options.nra_bound_min);
+    break;
+
+  case PARAM_MCSAT_NRA_MGCD:
+    print_boolean_value(g->mcsat_options.nra_mgcd);
+    break;
+
+  case PARAM_MCSAT_NRA_NLSAT:
+    print_boolean_value(g->mcsat_options.nra_nlsat);
     break;
 
   case PARAM_UNKNOWN:

--- a/src/frontend/smt2/smt2_commands.c
+++ b/src/frontend/smt2/smt2_commands.c
@@ -4750,11 +4750,11 @@ static void yices_set_option(smt2_globals_t *g, const char *param, const param_v
       g->ctx_parameters.var_elim = tt;
       context = g->ctx;
       if (context != NULL) {
-	if (tt) {
-	  enable_variable_elimination(context);
-	} else {
-	  disable_variable_elimination(context);
-	}
+        if (tt) {
+          enable_variable_elimination(context);
+        } else {
+          disable_variable_elimination(context);
+        }
       }
     }
     break;
@@ -4764,11 +4764,11 @@ static void yices_set_option(smt2_globals_t *g, const char *param, const param_v
       g->ctx_parameters.arith_elim = tt;
       context = g->ctx;
       if (context != NULL) {
-	if (tt) {
-	  enable_arith_elimination(context);
-	} else {
-	  disable_arith_elimination(context);
-	}
+        if (tt) {
+          enable_arith_elimination(context);
+        } else {
+          disable_arith_elimination(context);
+        }
       }
     }
     break;
@@ -4778,11 +4778,11 @@ static void yices_set_option(smt2_globals_t *g, const char *param, const param_v
       g->ctx_parameters.bvarith_elim = tt;
       context = g->ctx;
       if (context != NULL) {
-	if (tt) {
-	  enable_bvarith_elimination(context);
-	} else {
-	  disable_bvarith_elimination(context);
-	}
+        if (tt) {
+          enable_bvarith_elimination(context);
+        } else {
+          disable_bvarith_elimination(context);
+        }
       }
     }
     break;
@@ -4792,11 +4792,11 @@ static void yices_set_option(smt2_globals_t *g, const char *param, const param_v
       g->ctx_parameters.flatten_or = tt;
       context = g->ctx;
       if (context != NULL) {
-	if (tt) {
-	  enable_diseq_and_or_flattening(context);
-	} else {
-	  disable_diseq_and_or_flattening(context);
-	}
+        if (tt) {
+          enable_diseq_and_or_flattening(context);
+        } else {
+          disable_diseq_and_or_flattening(context);
+        }
       }
     }
     break;
@@ -4806,11 +4806,11 @@ static void yices_set_option(smt2_globals_t *g, const char *param, const param_v
       g->ctx_parameters.eq_abstraction = tt;
       context = g->ctx;
       if (context != NULL) {
-	if (tt) {
-	  enable_eq_abstraction(context);
-	} else {
-	  disable_eq_abstraction(context);
-	}
+        if (tt) {
+          enable_eq_abstraction(context);
+        } else {
+          disable_eq_abstraction(context);
+        }
       }
     }
     break;
@@ -4820,11 +4820,11 @@ static void yices_set_option(smt2_globals_t *g, const char *param, const param_v
       g->ctx_parameters.keep_ite = tt;
       context = g->ctx;
       if (context != NULL) {
-	if (tt) {
-	  enable_keep_ite(context);
-	} else {
-	  disable_keep_ite(context);
-	}
+        if (tt) {
+          enable_keep_ite(context);
+        } else {
+          disable_keep_ite(context);
+        }
       }
     }
     break;
@@ -4984,11 +4984,11 @@ static void yices_set_option(smt2_globals_t *g, const char *param, const param_v
       g->ctx_parameters.splx_eager_lemmas = tt;
       context = g->ctx;
       if (context != NULL) {
-	if (tt) {
-	  enable_splx_eager_lemmas(context);
-	} else {
-	  disable_splx_eager_lemmas(context);
-	}
+        if (tt) {
+          enable_splx_eager_lemmas(context);
+        } else {
+          disable_splx_eager_lemmas(context);
+        }
       }
     }
     break;
@@ -5022,11 +5022,11 @@ static void yices_set_option(smt2_globals_t *g, const char *param, const param_v
       g->ctx_parameters. splx_periodic_icheck = tt;
       context = g->ctx;
       if (context != NULL) {
-	if (tt) {
-	  enable_splx_periodic_icheck(context);
-	} else {
-	  disable_splx_periodic_icheck(context);
-	}
+        if (tt) {
+          enable_splx_periodic_icheck(context);
+        } else {
+          disable_splx_periodic_icheck(context);
+        }
       }
     }
     break;
@@ -5104,7 +5104,7 @@ static void yices_set_option(smt2_globals_t *g, const char *param, const param_v
       g->mcsat_options.nra_bound = tt;
       context = g->ctx;
       if (context != NULL) {
-        g->ctx->mcsat_options.nra_bound = tt;
+        context->mcsat_options.nra_bound = tt;
       }
     }
     break;
@@ -5114,7 +5114,7 @@ static void yices_set_option(smt2_globals_t *g, const char *param, const param_v
       g->mcsat_options.nra_bound_min = n;
       context = g->ctx;
       if (context != NULL) {
-        g->ctx->mcsat_options.nra_bound_min = n;
+        context->mcsat_options.nra_bound_min = n;
       }
     }
     break;
@@ -5124,7 +5124,7 @@ static void yices_set_option(smt2_globals_t *g, const char *param, const param_v
       g->mcsat_options.nra_bound_max = n;
       context = g->ctx;
       if (context != NULL) {
-        g->ctx->mcsat_options.nra_bound_max = n;
+        context->mcsat_options.nra_bound_max = n;
       }
     }
     break;
@@ -5134,7 +5134,7 @@ static void yices_set_option(smt2_globals_t *g, const char *param, const param_v
       g->mcsat_options.bv_var_size = n;
       context = g->ctx;
       if (context != NULL) {
-        g->ctx->mcsat_options.bv_var_size = n;
+        context->mcsat_options.bv_var_size = n;
       }
     }
     break;
@@ -5144,7 +5144,7 @@ static void yices_set_option(smt2_globals_t *g, const char *param, const param_v
       g->mcsat_options.var_order = terms;
       context = g->ctx;
       if (context != NULL) {
-        g->ctx->mcsat_options.var_order = terms;
+        context->mcsat_options.var_order = terms;
       }
     }
     break;

--- a/src/frontend/smt2/smt2_commands.c
+++ b/src/frontend/smt2/smt2_commands.c
@@ -3854,7 +3854,6 @@ static void init_smt2_globals(smt2_globals_t *g) {
   g->mcsat = false;
   init_ivector(&g->var_order, 0);
   init_mcsat_options(&g->mcsat_options);
-  g->mcsat_options.var_order = &g->var_order;
   g->efmode = false;
   init_ef_client(&g->ef_client);
   g->out = stdout;

--- a/src/frontend/smt2/smt2_commands.h
+++ b/src/frontend/smt2/smt2_commands.h
@@ -337,7 +337,8 @@ typedef struct smt2_globals_s {
   // mcsat
   bool mcsat;                      // set to true to use the mcsat solver
   mcsat_options_t mcsat_options;   // options for the mcsat solver
-
+  ivector_t var_order;             // order in which mcsat needs to assign variables
+  
   // exists/forall solver
   bool efmode;                     // true to use the exists_forall solver
   ef_client_t ef_client;

--- a/src/mcsat/options.c
+++ b/src/mcsat/options.c
@@ -25,5 +25,10 @@ extern void init_mcsat_options(mcsat_options_t *opts) {
   opts->nra_bound_min = -1;
   opts->nra_bound_max = -1;
   opts->bv_var_size = -1;
+  init_ivector(&opts->var_order, 0);
+}
+
+extern void delete_mcsat_options(mcsat_options_t *opts) {
+  delete_ivector(&opts->var_order);
 }
 

--- a/src/mcsat/options.c
+++ b/src/mcsat/options.c
@@ -18,6 +18,8 @@
 
 #include "options.h"
 
+#include <stddef.h>
+
 extern void init_mcsat_options(mcsat_options_t *opts) {
   opts->nra_nlsat = false;
   opts->nra_mgcd = false;
@@ -25,10 +27,6 @@ extern void init_mcsat_options(mcsat_options_t *opts) {
   opts->nra_bound_min = -1;
   opts->nra_bound_max = -1;
   opts->bv_var_size = -1;
-  init_ivector(&opts->var_order, 0);
-}
-
-extern void delete_mcsat_options(mcsat_options_t *opts) {
-  delete_ivector(&opts->var_order);
+  opts->var_order = NULL;
 }
 

--- a/src/mcsat/options.h
+++ b/src/mcsat/options.h
@@ -19,6 +19,8 @@
 #ifndef MCSAT_OPTIONS_H_
 #define MCSAT_OPTIONS_H_
 
+#include "utils/int_vectors.h"
+
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -32,10 +34,15 @@ typedef struct mcsat_options_s {
   int32_t nra_bound_min;
   int32_t nra_bound_max;
   int32_t bv_var_size;
+  // ordering for forcing assignment order
+  ivector_t var_order;
 } mcsat_options_t;
 
 /** Initialize options with default values. */
 extern void init_mcsat_options(mcsat_options_t *opts);
+
+/** Initialize options with default values. */
+extern void delete_mcsat_options(mcsat_options_t *opts);
 
 
 #endif /* MCSAT_OPTIONS_H_ */

--- a/src/mcsat/options.h
+++ b/src/mcsat/options.h
@@ -35,14 +35,10 @@ typedef struct mcsat_options_s {
   int32_t nra_bound_max;
   int32_t bv_var_size;
   // ordering for forcing assignment order
-  ivector_t var_order;
+  ivector_t* var_order;
 } mcsat_options_t;
 
 /** Initialize options with default values. */
 extern void init_mcsat_options(mcsat_options_t *opts);
-
-/** Initialize options with default values. */
-extern void delete_mcsat_options(mcsat_options_t *opts);
-
 
 #endif /* MCSAT_OPTIONS_H_ */

--- a/src/mcsat/solver.c
+++ b/src/mcsat/solver.c
@@ -1642,7 +1642,7 @@ bool mcsat_decide(mcsat_solver_t* mcsat) {
     if (trace_enabled(mcsat->ctx->trace, "mcsat::decide")) {
       FILE* out = trace_out(mcsat->ctx->trace);
       term_table_t* terms = mcsat->ctx->terms;
-      const ivector_t* vo = &mcsat->ctx->mcsat_options.var_order;
+      const ivector_t* vo = mcsat->ctx->mcsat_options.var_order;
       mcsat_trace_printf(mcsat->ctx->trace, "mcsat_decide(): var_order is ");
       for (i=0; i < vo->size; i++) {
         term_print_to_file(out, terms, vo->data[i]);

--- a/src/mcsat/solver.c
+++ b/src/mcsat/solver.c
@@ -1639,6 +1639,18 @@ bool mcsat_decide(mcsat_solver_t* mcsat) {
       }
     }
 
+    if (trace_enabled(mcsat->ctx->trace, "mcsat::decide")) {
+      FILE* out = trace_out(mcsat->ctx->trace);
+      term_table_t* terms = mcsat->ctx->terms;
+      const ivector_t* vo = &mcsat->ctx->mcsat_options.var_order;
+      mcsat_trace_printf(mcsat->ctx->trace, "mcsat_decide(): var_order is ");
+      for (i=0; i < vo->size; i++) {
+        term_print_to_file(out, terms, vo->data[i]);
+        mcsat_trace_printf(mcsat->ctx->trace, " ");
+      }
+      mcsat_trace_printf(mcsat->ctx->trace, "\n");
+    }
+    
     // Use the queue
     while (!var_queue_is_empty(&mcsat->var_queue) && var == variable_null) {
       // Get the next variable from the queue

--- a/src/mcsat/solver.c
+++ b/src/mcsat/solver.c
@@ -1644,9 +1644,11 @@ bool mcsat_decide(mcsat_solver_t* mcsat) {
       term_table_t* terms = mcsat->ctx->terms;
       const ivector_t* vo = mcsat->ctx->mcsat_options.var_order;
       mcsat_trace_printf(mcsat->ctx->trace, "mcsat_decide(): var_order is ");
-      for (i=0; i < vo->size; i++) {
-        term_print_to_file(out, terms, vo->data[i]);
-        mcsat_trace_printf(mcsat->ctx->trace, " ");
+      if (vo != NULL) {
+        for (i=0; i < vo->size; i++) {
+          term_print_to_file(out, terms, vo->data[i]);
+          mcsat_trace_printf(mcsat->ctx->trace, " ");
+        }
       }
       mcsat_trace_printf(mcsat->ctx->trace, "\n");
     }

--- a/src/mcsat/solver.c
+++ b/src/mcsat/solver.c
@@ -1619,10 +1619,36 @@ bool mcsat_decide(mcsat_solver_t* mcsat) {
   bool force_decision = false;
   while (true) {
 
-    // Get an unassigned variable from the queue
+    // Use the variable a plugin requested
     var = mcsat->top_decision_var;
     if (var != variable_null && trail_has_value(mcsat->trail, var)) {
       var = variable_null;
+    }
+
+    // If there is an order that was passed in, try that
+    if (var == variable_null) {
+      const ivector_t* order = mcsat->ctx->mcsat_options.var_order;
+      if (order != NULL) {
+        uint32_t i;
+        if (trace_enabled(mcsat->ctx->trace, "mcsat::decide")) {
+          FILE* out = trace_out(mcsat->ctx->trace);
+          fprintf(out, "mcsat_decide(): var_order is ");
+          for (i = 0; i < order->size; ++ i) {
+            term_print_to_file(out, mcsat->ctx->terms, order->data[i]);
+            fprintf(out, " ");
+          }
+          fprintf(out, "\n");
+        }
+        for (i = 0; var == variable_null && i < order->size; ++i) {
+          term_t ovar_term = order->data[i];
+          variable_t ovar = variable_db_get_variable_if_exists(mcsat->var_db, ovar_term);
+          assert(ovar != variable_null);
+          if (!trail_has_value(mcsat->trail, ovar)) {
+            var = ovar;
+            force_decision = true;
+          }
+        }
+      }
     }
 
     // Random decision:
@@ -1637,20 +1663,6 @@ bool mcsat_decide(mcsat_solver_t* mcsat) {
           // fprintf(stderr, "random\n");
         }
       }
-    }
-
-    if (trace_enabled(mcsat->ctx->trace, "mcsat::decide")) {
-      FILE* out = trace_out(mcsat->ctx->trace);
-      term_table_t* terms = mcsat->ctx->terms;
-      const ivector_t* vo = mcsat->ctx->mcsat_options.var_order;
-      mcsat_trace_printf(mcsat->ctx->trace, "mcsat_decide(): var_order is ");
-      if (vo != NULL) {
-        for (i=0; i < vo->size; i++) {
-          term_print_to_file(out, terms, vo->data[i]);
-          mcsat_trace_printf(mcsat->ctx->trace, " ");
-        }
-      }
-      mcsat_trace_printf(mcsat->ctx->trace, "\n");
     }
     
     // Use the queue


### PR DESCRIPTION
Added yices option for fixing variable order in mcsat:  :yices-mcsat-var-order.
--trace mcsat::decide currently shows this order before decisions are made