### PR TITLE
Mcsat bv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,6 @@ script:
 
 after_success:
   - if [[ $ENABLE_COVERAGE == ON ]]; then
-      lcov --directory build --base-directory src --capture --output-file coverage.info
-      coveralls-lcov coverage.info
+      lcov --directory build --base-directory src --capture --output-file coverage.info;
+      coveralls-lcov coverage.info;
     fi


### PR DESCRIPTION
Travis build complained about script code for coveralls
```
$ if [[ $ENABLE_COVERAGE == ON ]]; then lcov --directory build --base-directory src --capture --output-file coverage.info coveralls-lcov coverage.info fi
/home/travis/.travis/functions: eval: line 105: syntax error: unexpected end of file
```
Added two semi-colons to .travis.yml Travis build no longer complains about that.
Not sure how we got coveralls checks until now. Must have been through another route than the one I'm using, or maybe something changed in the way the .travis.yml is used...

Other changes are insignificant. I was cleaning up some code to make a commit to trigger travis.