### PR TITLE
Fix building on NetBSD.

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -214,14 +214,14 @@ build_subdirs: $(build_dir) $(dyn_objsubdirs) $(dyn_libdir) $(dyn_bindir)
 
 static_build_subdirs-mingw static_build_subdirs-cygwin: $(static_dll_objsubdirs)
 
-static_build_subdirs-darwin static_build_subdirs-linux static_build_subdirs-unix static_build_subdirs-freebsd:
+static_build_subdirs-darwin static_build_subdirs-linux static_build_subdirs-unix static_build_subdirs-freebsd static_build_subdirs-netbsd:
 
 static_build_subdirs: $(build_dir) $(static_objsubdirs) $(static_libdir) $(static_bindir) \
 	static_build_subdirs-$(POSIXOS)
 
 .PHONY: build_subdirs static_build_subdirs static_build_subdirs-darwin static-build_subdirs-cygwin \
 	static_build_subdirs-mingw static_build_subdirs-linux static_build_subdirs-unix \
-	static_build_subdirs-freebsd
+	static_build_subdirs-freebsd static_build_subdirs-netbsd
 
 #
 # Compilation
@@ -486,6 +486,9 @@ install-linux install-unix: install-default
 install-freebsd: install-default
 	$(LDCONFIG) -m $(DESTDIR)$(libdir) && (cd $(DESTDIR)$(libdir) && $(LN_S) -f libyices.so.$(MAJOR).$(MINOR) libyices.so)
 
+install-netbsd: install-default
+	(cd $(DESTDIR)$(libdir) && $(LN_S) -f libyices.so.$(YICES_VERSION) libyices.so)
+
 #
 # cygwin and mingw install: copy the DLLs in $(bindir)
 #
@@ -501,7 +504,7 @@ install-mingw: install-cygwin
 
 
 .PHONY: install install-default install-darwin install-solaris \
-	install-linux install-freebsd install-unix \
+	install-linux install-freebsd install-netbsd install-unix \
         install-cygwin install-mingw
 
 

--- a/autoconf/os
+++ b/autoconf/os
@@ -13,6 +13,8 @@ if eval 'uname > /dev/null 2> /dev/null'; then
       echo "mingw";;
     FreeBSD*)
       echo "freebsd";;
+    NetBSD*)
+      echo "netbsd";;
     *)
       echo "unix";;
   esac

--- a/configure.ac
+++ b/configure.ac
@@ -158,7 +158,7 @@ dnl For now, we check here and fail.
 dnl
 bigendian=""
 AC_C_BIGENDIAN([bigendian=yes],[bigendian=no],[bigendian=yes])
-if test "x$bigendian" == xyes ; then
+if test "x$bigendian" = xyes ; then
    AC_MSG_ERROR([Can't build for your architecture. Yices builds only on little-endian hardware. Please file an issue at $repo_url])
 fi
 
@@ -235,7 +235,7 @@ dnl
 static_libgmp=""
 AC_ARG_WITH([static-gmp],
    [AS_HELP_STRING([--with-static-gmp=<path>],[Full path to a static GMP library (e.g., libgmp.a)])],
-   [if test "x$withval" == x; then
+   [if test "x$withval" = x; then
       AC_MSG_WARN([--with-static-gmp was used but no path was given. Using defaults])
     else
       static_libgmp=$withval
@@ -247,7 +247,7 @@ static_includegmp=""
 AC_ARG_WITH([static-gmp-include-dir],
    [AS_HELP_STRING([--with-static-gmp-include-dir=<directory>],
             [Directory of include file "gmp.h" compatible with static GMP library])],
-   [if test "x$withval" == x; then
+   [if test "x$withval" = x; then
       AC_MSG_WARN([--with-static-gmp-include-dir was used but no directory was given. Using defaults])
     else
       static_includegmp=$withval
@@ -259,7 +259,7 @@ AC_ARG_WITH([static-gmp-include-dir],
 pic_libgmp=""
 AC_ARG_WITH([pic-gmp],
    [AS_HELP_STRING([--with-pic-gmp=<path>],[Full path to a relocatable GMP library (e.g., libgmp.a)])],
-   [if test "x$withval" == x; then
+   [if test "x$withval" = x; then
       AC_MSG_WARN([--with-pic-gmp was used but no path was given. Using defaults])
     else
       pic_libgmp=$withval
@@ -271,7 +271,7 @@ pic_includegmp=""
 AC_ARG_WITH([pic-gmp-include-dir],
    [AS_HELP_STRING([--with-pic-gmp-include-dir=<directory>],
             [Directory of include file "gmp.h" compatible with relocatable GMP library])],
-   [if test "x$withval" == x; then
+   [if test "x$withval" = x; then
       AC_MSG_WARN([--with-pic-gmp-include-dir was used but no directory was given. Using defaults])
     else
       pic_includegmp=$withval
@@ -301,10 +301,10 @@ AC_ARG_ENABLE([mcsat],
 static_lpoly=""
 AC_ARG_WITH([static-libpoly],
    [AS_HELP_STRING([--with-static-libpoly=<path>],[Full path to libpoly.a])],
-   [if test $use_mcsat == "no" ; then
+   [if test $use_mcsat = "no" ; then
       AC_MSG_WARN([Ignoring option --with-static-libpoly since MCSAT support is disabled])
     else
-      if test "x$withval" == x; then
+      if test "x$withval" = x; then
         AC_MSG_WARN([--with-static-poly was used but no path was given. Using defaults])
       else
         static_lpoly=$withval
@@ -317,10 +317,10 @@ static_includelpoly=""
 AC_ARG_WITH([static-libpoly-include-dir],
    [AS_HELP_STRING([--with-static-libpoly-include-dir=<directory>],
             [Path to include files compatible with libpoly.a (e.g., /usr/local/include)])],
-   [if test $use_mcsat == "no" ; then
+   [if test $use_mcsat = "no" ; then
       AC_MSG_WARN([Ignoring option --with-static-libpoly-include-dir since MCSAT support is disabled])
     else
-      if test "x$withval" == x; then
+      if test "x$withval" = x; then
          AC_MSG_WARN([--with-static-libpoly-include-dir was used but no directory was given. Using defaults])
       else
         static_includelpoly=$withval
@@ -333,10 +333,10 @@ AC_ARG_WITH([static-libpoly-include-dir],
 pic_lpoly=""
 AC_ARG_WITH([pic-libpoly],
    [AS_HELP_STRING([--with-pic-libpoly=<path>],[Full path to a relocatable libpoly.a])],
-   [if test $use_mcsat == "no" ; then
+   [if test $use_mcsat = "no" ; then
       AC_MSG_WARN([Ignoring option --with-pic-libpoly since MCSAT support is disabled])
     else
-      if test "x$withval" == x; then
+      if test "x$withval" = x; then
          AC_MSG_WARN([--with-pic-libpoly was used but no path was given. Using defaults])
       else
          pic_lpoly=$withval
@@ -349,10 +349,10 @@ pic_includelpoly=""
 AC_ARG_WITH([pic-libpoly-include-dir],
    [AS_HELP_STRING([--with-pic-libpoly-include-dir=<directory>],
             [Path to include files compatible with the relocatable libpoly.a])],
-   [if test $use_mcsat == "no" ; then
+   [if test $use_mcsat = "no" ; then
       AC_MSG_WARN([Ignoring option --with-pic-libpoly-include-dir since MCSAT support is disabled])
     else
-      if test "x$withval" == x; then
+      if test "x$withval" = x; then
          AC_MSG_WARN([--with-pic-libpoly-include-dir was used but no directory was given. Using defaults])
       else
          pic_includelpoly=$withval
@@ -860,7 +860,7 @@ fi
 # ------------------
 #
 AC_SUBST(THREAD_SAFE)
-if test "x$thread_safe" == xyes ; then
+if test "x$thread_safe" = xyes ; then
    THREAD_SAFE=1
    # iam: the aim is to eventually eliminate this restriction, but not before the 2.6.2 release.
    if test $use_mcsat = yes ; then
@@ -873,10 +873,10 @@ dnl Test support for thread-local storage
 dnl -------------------------------------
 dnl
 AC_SUBST(HAVE_TLS)
-if test "x$thread_safe" == xyes ; then
+if test "x$thread_safe" = xyes ; then
    has_tls=""
    CSL_CHECK_THREAD_LOCAL
-   if test "x$has_tls" == xyes; then
+   if test "x$has_tls" = xyes; then
       HAVE_TLS=1
    else
       AC_MSG_ERROR([Building with --enable-thread-safety requires thread-local storage])
@@ -905,7 +905,7 @@ if test ! -d configs ; then
   AS_MKDIR_P([configs])
 fi
 
-if test "x$host" == x ; then
+if test "x$host" = x ; then
   AC_MSG_NOTICE([Moving make.include to configs/make.include.$build])
   mv make.include "configs/make.include.$build"
 else

--- a/src/Makefile
+++ b/src/Makefile
@@ -656,6 +656,18 @@ ifeq ($(POSIXOS),freebsd)
   static_libyices_dynamic=$(static_libdir)/$(libyices_so)
 
 else
+ifeq ($(POSIXOS),netbsd)
+  PIC=-fPIC
+  STATIC=-static
+  CPPFLAGS := $(CPPFLAGS) -DNETBSD
+  CFLAGS += -fvisibility=hidden $(PTHREAD)
+  BIN_LDFLAGS=
+  libyices_dynamic=$(libdir)/$(libyices_so)
+  # Dynamic library can't be built from .a files because
+  # they aren't normally built with -fPIC.
+  static_libyices_dynamic=
+
+else
 ifeq ($(POSIXOS),unix)
   PIC=-fPIC
   STATIC=-static
@@ -666,6 +678,7 @@ ifeq ($(POSIXOS),unix)
   static_libyices_dynamic=$(static_libdir)/$(libyices_so)
 else
  $(error "Don't know how to compile on $(POSIXOS)")
+endif
 endif
 endif
 endif
@@ -1134,7 +1147,7 @@ static-bin: $(static_binaries)
 # Libraries
 lib: $(libyices) $(libyices_dynamic)
 
-static-lib: $(static_libyices) $(static_libyices_dynamic)
+static-lib: $(static_libyices)
 
 
 .PHONY: obj static-obj bin static-bin lib static-lib

--- a/src/utils/bit_tricks.h
+++ b/src/utils/bit_tricks.h
@@ -55,6 +55,11 @@
 #include <stdint.h>
 #include <assert.h>
 
+#ifdef NETBSD
+/* NetBSD has popcount in libc. */
+#include <strings.h>
+#endif
+
 
 #ifdef __GNUC__
 
@@ -101,9 +106,11 @@ static inline uint32_t clz(uint32_t x) {
   return __builtin_clzl(x);
 }
 
+#ifndef NETBSD
 static inline uint32_t popcount32(uint32_t x) {
   return __builtin_popcountl(x);
 }
+#endif
 
 #else
 //#warning "ctz: uint32_t is (unsigned int)"
@@ -118,9 +125,11 @@ static inline uint32_t clz(uint32_t x) {
   return __builtin_clz(x);
 }
 
+#ifndef NETBSD
 static inline uint32_t popcount32(uint32_t x) {
   return __builtin_popcount(x);
 }
+#endif
 
 #endif
 
@@ -141,9 +150,11 @@ static inline uint32_t clz64(uint64_t x) {
   return __builtin_clzll(x);
 }
 
+#ifndef NETBSD
 static inline uint32_t popcount64(uint64_t x) {
   return __builtin_popcountll(x);
 }
+#endif
 
 #else
 // #warning "bit_tricks: uint64_t is (unsigned long)
@@ -158,9 +169,11 @@ static inline uint32_t clz64(uint64_t x) {
   return __builtin_clzl(x);
 }
 
+#ifndef NETBSD
 static inline uint32_t popcount64(uint64_t x) {
   return __builtin_popcountl(x);
 }
+#endif
 
 #endif // 64bit versions
 
@@ -223,6 +236,7 @@ static inline uint32_t clz64(uint64_t x) {
   return i;
 }
 
+#ifndef NETBSD
 static inline uint32_t popcount32(uint32_t x) {
   uint32_t c;
 
@@ -246,6 +260,7 @@ static inline uint32_t popcount64(uint64_t x) {
 
   return c;
 }
+#endif /* #ifndef NETBSD */
 
 #endif
 


### PR DESCRIPTION
 - Don't invoke static_libyices_dynamic target because
   dynamic libraries can't be built from .a files which
   aren't normally built with -fPIC.
 - POSIX shell uses "=" for comparisons rather than "==".
 - NetBSD has popcount in libc.
 - There is no ldconfig on NetBSD.