### PR TITLE
Allow build using GNU GCC on MacOS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -641,12 +641,17 @@ ifeq ($(POSIXOS),mingw)
 else
 ifeq ($(POSIXOS),darwin)
   CPPFLAGS := $(CPPFLAGS) -DMACOSX
-  CFLAGS += -fvisibility=hidden $(PTHREAD) -Qunused-arguments
+  CFLAGS += -fvisibility=hidden $(PTHREAD)
   PIC=-fPIC
   STATIC=
   BIN_LDFLAGS=
   libyices_dynamic=$(libdir)/$(libyices_dylib)
   static_libyices_dynamic=$(static_libdir)/$(libyices_dylib)
+  
+  # Detect clang-disguised-as-gcc vs. GNU GCC
+  ifeq ($(shell $(CC) -v 2>&1 | grep -c "clang version"), 1)
+    CFLAGS += -Qunused-arguments
+  endif
 else
 ifeq ($(POSIXOS),sunos)
   PIC=-fPIC


### PR DESCRIPTION
src/Makefile:644 appends '-Qunused-arguments' to CFLAGS, which assumes Clang is
used for the build. This PR adds some detection to distinguish between
clang-disguised-as-gcc and true GNU GCC, omitting the argument in the latter
case.

This change was tested in the following configurations:
- System compiler (/usr/bin/gcc)
- GCC 9.2 from Brew
- LLVM 9 from Brew