### PR TITLE
Flush output buffer after writing solver status.

### DIFF
--- a/src/frontend/smt2/smt2_commands.c
+++ b/src/frontend/smt2/smt2_commands.c
@@ -1478,6 +1478,7 @@ static void report_ef_status(smt2_globals_t *g, ef_client_t *efc) {
   case EF_STATUS_INTERRUPTED:
     trace_printf(g->tracer, 3, "(exist/forall solver: %"PRIu32" iterations)\n", efsolver->iters);
     print_out("%s\n", ef_status2string[stat]);
+    flush_out();
     break;
 
   case EF_STATUS_SUBST_ERROR:

--- a/src/frontend/yices_sat.c
+++ b/src/frontend/yices_sat.c
@@ -481,6 +481,8 @@ static void print_results(void) {
   } else {
     printf("unknown\n");
   }
+
+  fflush(stdout);
 }
 
 


### PR DESCRIPTION
I had some trouble getting Yices to work with Yosys when in exists-forall mode.  The integrated solver interface yosys-smtbmc would hang on satisfiable instances, seemingly never reading the `sat` line.  It turns out this is because the `__smt_globals.out` fd is not flushed after the status is printed to it.

This PR adds that flush, along with another apparently missing flush in `frontend/yices_sat.c`.