### PR TITLE
Correct a typo: The proper SMT2 command prefix to set Yices options is `:yices-`.

### DIFF
--- a/src/frontend/common/parameters.c
+++ b/src/frontend/common/parameters.c
@@ -29,7 +29,7 @@
 
 /*
  * Parameter names: using the Yices conventions
- * - for the smt2 front end, you prefix these names with ':yices:'
+ * - for the smt2 front end, you prefix these names with ':yices-'
  */
 static const char * const param_names[NUM_PARAMETERS] = {
   "arith-elim",


### PR DESCRIPTION
I was initially misled by this comment.  Obviously it didn't work, so I followed the code path and saw the definition of`YICES_SMT2_PREFIX` in `frontend/smt2/smt2_commands.c`.