### PR TITLE
Closes #210.  Adds support for `timeout` command line argument in exists-forall mode.

### DIFF
--- a/src/exists_forall/efsolver.c
+++ b/src/exists_forall/efsolver.c
@@ -187,6 +187,22 @@ void delete_ef_solver(ef_solver_t *solver) {
 }
 
 
+/*
+ * Stop the exists-forall search.
+ */
+void ef_solver_stop_search(ef_solver_t *solver) {
+  context_t *exists_ctx, *forall_ctx;
+
+  exists_ctx = solver->exists_context;
+  forall_ctx = solver->forall_context;
+
+  assert(solver->status == EF_STATUS_SEARCHING);
+
+  solver->status = EF_STATUS_INTERRUPTED;
+  if (exists_ctx != NULL && context_status(exists_ctx) == STATUS_SEARCHING) context_stop_search(exists_ctx);
+  else if (forall_ctx != NULL && context_status(forall_ctx) == STATUS_SEARCHING) context_stop_search(forall_ctx);
+}
+
 
 /*
  * Set the trace:

--- a/src/frontend/smt2/smt2_commands.c
+++ b/src/frontend/smt2/smt2_commands.c
@@ -2490,7 +2490,9 @@ static void timeout_handler(void *data) {
   assert(data == &__smt2_globals);
 
   g = data;
-  if (g->ctx != NULL && context_status(g->ctx) == STATUS_SEARCHING) {
+  if (g->efmode && g->ef_client.efsolver != NULL && g->ef_client.efsolver->status == EF_STATUS_SEARCHING) {
+	ef_solver_stop_search(g->ef_client.efsolver);
+  } else if (g->ctx != NULL && context_status(g->ctx) == STATUS_SEARCHING) {
     context_stop_search(g->ctx);
   }
 }
@@ -3054,9 +3056,18 @@ static void efsolve_cmd(smt2_globals_t *g) {
 
   if (g->efmode) {
     efc = &g->ef_client;
+    if (g->timeout != 0) {
+      if (!g->timeout_initialized) {
+        init_timeout();
+        g->timeout_initialized = true;
+      }
+      g->interrupted = false;
+      start_timeout(g->timeout, timeout_handler, g);
+    }
     ef_solve(efc, g->assertions.size, g->assertions.data, &g->parameters,
              qf_fragment(g->logic_code), ef_arch_for_logic(g->logic_code),
              g->tracer);
+    clear_timeout();
 
     if (efc->efcode != EF_NO_ERROR) {
       // error in preprocessing


### PR DESCRIPTION
It was a bit of a journey following the control flow to the right place, but it turned out to be quite easy to implement this.  You even stubbed out `ef_solver_stop_search()` for me already.  Thanks :)