### PR TITLE
Disteph master

### DIFF
--- a/src/mcsat/bv/explain/arith.c
+++ b/src/mcsat/bv/explain/arith.c
@@ -1389,7 +1389,9 @@ bool can_explain_conflict(bv_subexplainer_t* this, const ivector_t* conflict_cor
       ctx_trace_term(ctx, csttrail->conflict_var_term);
     }
 
-    switch (term_kind(terms, atom_term)) {
+    term_kind_t kind = term_kind(terms, atom_term);
+
+    switch (kind) {
     case EQ_TERM : 
     case BV_EQ_ATOM:
     case BV_GE_ATOM: 
@@ -1454,7 +1456,9 @@ bool can_explain_conflict(bv_subexplainer_t* this, const ivector_t* conflict_cor
         result = false;
         break;
       }
-      if (t0_coeff * t1_coeff == -1) {
+      if ( (kind != EQ_TERM)
+           && (kind != BV_EQ_ATOM)
+           && (t0_coeff * t1_coeff == -1) ) {
         // Turns out we actually can't deal with the constraint. We stop
         if (ctx_trace_enabled(ctx, "mcsat::bv::arith::fail")) {
           FILE* out = ctx_trace_out(ctx);

--- a/src/mcsat/bv/explain/arith_norm.c
+++ b/src/mcsat/bv/explain/arith_norm.c
@@ -869,10 +869,8 @@ term_t arith_normalise_upto(arith_norm_t* norm, term_t u, uint32_t w){
   }
 
   default: {
-    assert(!is_boolean_term(terms,t));
-    term_t tmp = term_extract(tm, t, 0, w);
-    arith_analyse_t* analysis = arith_analyse(norm, tmp);
-    return finalise(norm, t, analysis);
+    assert(false);
+    return NULL_TERM; // Just to prevent compiler complaining
   }
   }
 }

--- a/src/mcsat/bv/explain/arith_utils.c
+++ b/src/mcsat/bv/explain/arith_utils.c
@@ -1,8 +1,19 @@
 /*
- * The Yices SMT Solver. Copyright 2015 SRI International.
+ * This file is part of the Yices SMT Solver.
+ * Copyright (C) 2019 SRI International.
  *
- * This program may only be used subject to the noncommercial end user
- * license agreement which is downloadable along with this program.
+ * Yices is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Yices is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Yices.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "mcsat/tracing.h"

--- a/src/mcsat/bv/explain/arith_utils.c
+++ b/src/mcsat/bv/explain/arith_utils.c
@@ -1,19 +1,8 @@
 /*
- * This file is part of the Yices SMT Solver.
- * Copyright (C) 2019 SRI International.
+ * The Yices SMT Solver. Copyright 2015 SRI International.
  *
- * Yices is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * Yices is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with Yices.  If not, see <http://www.gnu.org/licenses/>.
+ * This program may only be used subject to the noncommercial end user
+ * license agreement which is downloadable along with this program.
  */
 
 #include "mcsat/tracing.h"
@@ -231,7 +220,7 @@ term_t arith_eq0(term_manager_t* tm, term_t t) {
     bvarith_buffer_prepare(buffer, w); // Setting the desired width
     for (uint32_t i = 0; i < t_poly->nterms; ++ i) {
       term_t monom_var = t_poly->mono[i].var;
-      if (bvconst_tst_bit(t_poly->mono[i].coeff, w-1)) { // coefficient is positive
+      if (!bvconst_tst_bit(t_poly->mono[i].coeff, w-1)) { // coefficient is positive
         if (monom_var == const_idx) // constant coefficient gets aded to the buffer bv_poly
           bvarith_buffer_add_const(buffer, t_poly->mono[i].coeff);
         else // Otherwise we add the w-bit monomial to the bv_poly
@@ -242,7 +231,7 @@ term_t arith_eq0(term_manager_t* tm, term_t t) {
     bvarith_buffer_prepare(buffer, w); // Setting the desired width
     for (uint32_t i = 0; i < t_poly->nterms; ++ i) {
       term_t monom_var = t_poly->mono[i].var;
-      if (!bvconst_tst_bit(t_poly->mono[i].coeff, w-1)) { // coefficient is negative
+      if (bvconst_tst_bit(t_poly->mono[i].coeff, w-1)) { // coefficient is negative
         bvconstant_t coeff;
         init_bvconstant(&coeff);
         bvconstant_copy(&coeff, w, t_poly->mono[i].coeff);
@@ -264,7 +253,7 @@ term_t arith_eq0(term_manager_t* tm, term_t t) {
     // Now going into each monomial
     for (uint32_t i = 0; i < t_poly->nterms; ++ i) {
       term_t monom_var = t_poly->mono[i].var;
-      if (tst_bit64(t_poly->mono[i].coeff, w-1)) { // coefficient is positive
+      if (!tst_bit64(t_poly->mono[i].coeff, w-1)) { // coefficient is positive
         if (monom_var == const_idx) // constant coefficient gets added to the buffer bv_poly
           bvarith64_buffer_add_const(buffer, t_poly->mono[i].coeff);
         else // Otherwise we add the w-bit monomial to the bv_poly
@@ -275,7 +264,7 @@ term_t arith_eq0(term_manager_t* tm, term_t t) {
     bvarith64_buffer_prepare(buffer, w); // Setting the desired width
     for (uint32_t i = 0; i < t_poly->nterms; ++ i) {
       term_t monom_var = t_poly->mono[i].var;
-      if (!tst_bit64(t_poly->mono[i].coeff, w-1)) { // coefficient is negative
+      if (tst_bit64(t_poly->mono[i].coeff, w-1)) { // coefficient is negative
         if (monom_var == const_idx)
           bvarith64_buffer_add_const(buffer, - t_poly->mono[i].coeff); // constant coefficient gets added to the buffer bv_poly
         else
@@ -330,8 +319,9 @@ term_t arith_le(term_manager_t* tm, term_t left, term_t right) {
     return true_term;
   }
   // (left <= 0) and (-1 <= right) turns into (left == right)
-  if (arith_is_zero(terms, right)) {
-    return arith_eq0(tm, left);
+  if (arith_is_zero(terms, right)
+      || arith_is_minus_one(terms, left)) {
+    return arith_eq0(tm, arith_sub(tm, left, right));
   }
   // (1 <= right) turns into (right != 0)
   if (arith_is_one(terms, left)) {

--- a/src/mcsat/bv/explain/arith_utils.c
+++ b/src/mcsat/bv/explain/arith_utils.c
@@ -401,7 +401,9 @@ term_t arith_sum_norm(term_manager_t* tm, term_t u) {
             bvconstant_t newcoeff;
             init_bvconstant(&newcoeff);
             bvconstant_copy(&newcoeff, w, coeff);
-            bvconst_shift_right(newcoeff.data, w, shift, false);
+            bool sign_bit = bvconst_tst_bit(newcoeff.data, w-1);
+            bvconst_shift_right(newcoeff.data, w, shift, sign_bit); // arithmetic right shift
+            bvconstant_normalize(&newcoeff);
             // Now we build the new monomial variable
             term_t sbits[w];
             for (uint32_t k=0; k<w; k++){
@@ -435,7 +437,7 @@ term_t arith_sum_norm(term_manager_t* tm, term_t u) {
           uint32_t shift = ctz64(coeff);
           assert(shift < w);
           if (shift > 0) { // Coefficient is even, we rewrite
-            coeff = bvconst64_lshr(coeff, (uint64_t) shift, w);
+            coeff = bvconst64_ashr(coeff, (uint64_t) shift, w);
             assert(tst_bit64(coeff, 0));
             // Now we build the new monomial variable
             term_t sbits[w];

--- a/src/mcsat/bv/explain/arith_utils.h
+++ b/src/mcsat/bv/explain/arith_utils.h
@@ -74,6 +74,10 @@ term_t arith_lt(term_manager_t* tm, term_t left, term_t right);
 // This function returns (left <= right), simplifying the result
 term_t arith_le(term_manager_t* tm, term_t left, term_t right);
 
+/**
+   Normalising sums so that coefficients are odd.
+**/
+
 // Outputs true if
 // - not a bv_poly or bv64 poly, or;
 // - if it is a bv_poly or bv64_poly, and none of the (non-constant) coefficients is even
@@ -83,6 +87,10 @@ bool arith_is_sum_norm(term_table_t* terms, term_t t);
 // if one of the (non-constant) coefficients is even it can be divided by 2 and the monomial's variable could be multiplied by 2 by a shift.
 // This simplification is done iteratively until the property above is true.
 term_t arith_sum_norm(term_manager_t* tm, term_t u);
+
+/**
+   Apparently useful somewhere.
+**/
 
 static inline
 bool arith_is_no_triv(term_t t){


### PR DESCRIPTION
- allowing bv_arith explainer to handle negative powers of 2
- fixed sign convention for the equalities produced by the bv_arith explainer, now avoiding (-1 * x) = (-1 * y) and producing( x = y ) instead
Slight improvement of performance.