### PR TITLE
Disteph master

### DIFF
--- a/src/mcsat/bv/explain/arith_utils.c
+++ b/src/mcsat/bv/explain/arith_utils.c
@@ -375,17 +375,15 @@ bool arith_is_sum_norm(term_table_t* terms, term_t t) {
 // returns the number of low bit zeros in t
 term_t term_zeros(term_manager_t* tm, term_t t) {
   term_table_t* terms = tm->terms;
-  switch (term_kind(terms, t)) {
-  case BV_ARRAY: {  // Concatenated boolean terms
+  if (term_kind(terms, t) == BV_ARRAY) {  // Concatenated boolean terms
     composite_term_t* concat_desc = bvarray_term_desc(terms, t);
     uint32_t w = term_bitsize(terms, t);
-    // First, we copy the array of bits
     for (uint32_t i = 0; i < w; i++)
       if (concat_desc->arg[i] != false_term)
         return i;
     return w;
-  }
-  default: return 0;
+  } else {
+    return 0;
   }
 }
 


### PR DESCRIPTION
New optimisation: in monomial (coeff * variable), if variable is of the form (concat x 0...0), with n trailing zeros on the low bits side, then the upper n bits of the coeff constant don't matter, they'll overflow during multiplication. So we can set them to whatever is convenient, e.g. 0...0 or 1...1, if it helps turning coeff into 1 or -1.
Performance review on 3-min timeout on QF_BV:
- new instances solved: 26 / instances no longer solved: 12
- instances solved faster (by > 2sec): 294 / instances solved more slowly: 256
