### PR TITLE
Add support for cross compiling 32-bit windows version on linux with mingw

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,11 @@ ifneq ($(OPTION),)
   ifeq ($(POSIXOS),linux)
     ifeq ($(OPTION),32bits)
       newarch=$(subst x86_64,i686,$(ARCH))
+    else
+    ifeq ($(OPTION),mingw32)
+      newarch=i686-w64-mingw32
+      POSIXOS=mingw
+    endif
     endif
   else
   ifeq ($(POSIXOS),darwin)

--- a/configure.ac
+++ b/configure.ac
@@ -540,7 +540,7 @@ if ((__GNU_MP_VERSION < 4) ||
   }
 ]])
 
-],run_ok=yes,run_ok=no,run_ok=no)
+],run_ok=yes,run_ok=no,run_ok=yes)
 AC_MSG_RESULT([$run_ok])
 #
 # restore CPPFLAGS and LIBS


### PR DESCRIPTION
Example build order:
```
autoconf
./configure --host=i686-w64-mingw32 CPPFLAGS=-I/home/test/static_gmp/include LDFLAGS=-L/home/test/static_gmp/lib --with-static-gmp=/home/test/static_gmp/lib/libgmp.a --with-static-gmp-include-dir=/home/test/static_gmp/include
make static-dist OPTION=mingw32
```

In makefile newarch is explicitly set to i686-w64-mingw32. Since I've tested on only one mingw version, I don't have data to generalize this code.
In configure.ac, code for checking if libgmp is recent enough is changed. The original version failed this check in case of crosscompiling. The new one succeeds without a real check, since there is no easy way to run the code for windows on linux. This modification affects all cross builds, not only on linux for windows. Since the original code failed, I assume crosscompilation was not used, so no other build will break.