### PR TITLE
Add new API coverage test

### DIFF
--- a/tests/api/term_utils.c
+++ b/tests/api/term_utils.c
@@ -1,0 +1,38 @@
+/* Achieves the following additional coverage:
+ * api/yices_api.c:yices_arith_geq_atom()
+ * terms/term_utils.c:finite_domain_is_nonpos(), exiting via `return false`
+ *                    term_has_nonpos_finite_domain()
+ *                    arith_term_is_nonpos(), case `ITE_SPECIAL`
+ */
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
+#include <assert.h>
+
+#include "yices.h"
+
+int main(void) {
+    yices_init();
+
+    ctx_config_t* config = yices_new_config();
+    yices_default_config_for_logic(config, "QF_LIA");
+    context_t* ctx = yices_new_context(config);
+
+    term_t x = yices_new_uninterpreted_term(yices_int_type());
+    yices_set_term_name(x, "x");
+
+    term_t one = yices_int32(1);
+    term_t ite_term = yices_ite(yices_arith_geq_atom(one, x), yices_int32(-1), one);
+    term_t abs_term = yices_abs(ite_term);
+
+    yices_assert_formula(ctx, yices_eq(abs_term, one));
+    assert(yices_check_context(ctx, NULL) == STATUS_SAT);
+    assert(!yices_error_code());
+
+    yices_free_context(ctx);
+    yices_exit();
+
+    return 0;
+}


### PR DESCRIPTION
This test uses `QF_LIA` instead of the usual `QF_NIA`, therefore I have
removed the check for compilation with`mcsat`. Let me know if this is wrong,
or if the theory should be kept to `QF_NIA` for these tests.

Additional coverage:
api/yices_api.c:yices_arith_geq_atom()
terms/term_utils.c:finite_domain_is_nonpos(), exiting via `return false`
                   term_has_nonpos_finite_domain()
                   arith_term_is_nonpos(), case `ITE_SPECIAL`