### PR TITLE
Makefile.build: avoid ldconfig on linux

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -491,8 +491,11 @@ install-darwin: install-default
 install-solaris: install-default
 	$(LDCONFIG) -n $(DESTDIR)$(libdir) && (cd $(DESTDIR)$(libdir) && $(LN_S) -f libyices.so.$(YICES_VERSION) libyices.so)
 
+# Avoid ldconfig as it's not present on musl. We create the following symlinks:
+# - libyices.so.X.Y.Z -> libyices.so.X.Y
+# - libyices.so.X.Y   -> libyices.so
 install-linux install-unix: install-default
-	$(LDCONFIG) -n $(DESTDIR)$(libdir) && (cd $(DESTDIR)$(libdir) && $(LN_S) -f libyices.so.$(YICES_VERSION) libyices.so)
+	(cd $(DESTDIR)$(libdir) && $(LN_S) -f libyices.so.$(YICES_VERSION) libyices.so.$(MAJOR).$(MINOR) && $(LN_S) -f libyices.so.$(MAJOR).$(MINOR) libyices.so)
 
 # on FreeBSD: the library file is libyices.so.X.Y and ldconfig does not take -n
 # TODO: fix this. We must also create a symbolic link: libyices.so.X in libdir


### PR DESCRIPTION
linux-musl target does not provide ldconfig:
    https://wiki.musl-libc.org/faq.html#Q:-Where-is-%3Ccode%3Eldconfig%3C/code%3E?

Let's create explicit hierarchy of symlinks to avoid dependency on ldconfig's behaviour.