### PR TITLE
Makefile: add PPC support for Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ YICES_VERSION = $(MAJOR).$(MINOR).$(PATCH_LEVEL)
 #
 ARCH=$(shell ./config.sub `./config.guess`)
 POSIXOS=$(shell ./autoconf/os)
+PLATFORM=$(shell uname -p)
 
 ifeq (,$(POSIXOS))
   $(error "Problem running ./autoconf/os")
@@ -150,12 +151,22 @@ ifneq ($(OPTION),)
     endif
   else
   ifeq ($(POSIXOS),darwin)
-    ifeq ($(OPTION),64bits)
-      newarch=$(subst i386,x86_64,$(ARCH))
+    ifeq ($(PLATFORM),powerpc)
+      ifeq ($(OPTION),64bits)
+        newarch=$(subst powerpc,powerpc64,$(ARCH))
+      else
+      ifeq ($(OPTION),32bits)
+        newarch=$(subst powerpc64,powerpc,$(ARCH))
+      endif
+      endif
     else
-    ifeq ($(OPTION),32bits)
-      newarch=$(subst x86_64,i386,$(ARCH))
-    endif
+      ifeq ($(OPTION),64bits)
+        newarch=$(subst i386,x86_64,$(ARCH))
+      else
+      ifeq ($(OPTION),32bits)
+        newarch=$(subst x86_64,i386,$(ARCH))
+      endif
+      endif
     endif
   else
   ifeq ($(POSIXOS),cygwin)


### PR DESCRIPTION
Will this be a correct way to introduce PPC for Darwin?
It does build for me locally.

P. S. PPC itself will likely need fixes, since most of tests fail atm: https://github.com/SRI-CSL/yices2/issues/424
However fixing Makefile to enable PPC is the first necessary step.