### PR TITLE
Update weq term rep

### DIFF
--- a/src/mcsat/eq/equality_graph.c
+++ b/src/mcsat/eq/equality_graph.c
@@ -1340,6 +1340,11 @@ const mcsat_value_t* eq_graph_get_propagated_term_value(const eq_graph_t* eq, te
   return eq->values_list.data + n_find->index;
 }
 
+eq_node_id_t eq_graph_get_propagated_term_value_id(const eq_graph_t* eq, term_t t) {
+  const mcsat_value_t* val = eq_graph_get_propagated_term_value(eq, t);
+  return eq_graph_value_id(eq, val);
+}
+
 void eq_graph_propagate_trail(eq_graph_t* eq) {
 
   if (ctx_trace_enabled(eq->ctx, "mcsat::eq")) {

--- a/src/mcsat/eq/equality_graph.h
+++ b/src/mcsat/eq/equality_graph.h
@@ -296,6 +296,9 @@ bool eq_graph_has_propagated_term_value(const eq_graph_t* eq, term_t t);
 /** Get the value of a propagated term. */
 const mcsat_value_t* eq_graph_get_propagated_term_value(const eq_graph_t* eq, term_t t);
 
+/** Get the eq_node_id of a propagated term value. */
+eq_node_id_t eq_graph_get_propagated_term_value_id(const eq_graph_t* eq, term_t t);
+
 /** Propagate the trail */
 void eq_graph_propagate_trail(eq_graph_t* eq);
 

--- a/src/mcsat/uf/uf_plugin.c
+++ b/src/mcsat/uf/uf_plugin.c
@@ -385,13 +385,17 @@ void uf_plugin_propagate(plugin_t* plugin, trail_token_t* prop) {
       uint32_t i;
       for (i = 0; i < uf->conflict.size; ++i) {
         t = uf->conflict.data[i];
-        if (term_kind(terms, t) == EQ_TERM) {
+	ctx_trace_printf(uf->ctx, "TERM IS : ");
+	ctx_trace_term(uf->ctx, t);
+	if (term_kind(terms, t) == EQ_TERM) {
           t_desc = eq_term_desc(terms, t);
-          int_mset_add(&uf->tmp, t_desc->arg[0]);
-          int_mset_add(&uf->tmp, t_desc->arg[1]);
-        } else {
+        } else if (term_kind(terms, t) == BV_EQ_ATOM) {
+	  t_desc = bveq_atom_desc(terms, t);
+	} else {
           assert(false);
         }
+	int_mset_add(&uf->tmp, t_desc->arg[0]);
+	int_mset_add(&uf->tmp, t_desc->arg[1]);
       }
       uf_plugin_bump_terms_and_reset(uf, &uf->tmp);
       statistic_avg_add(uf->stats.avg_conflict_size, uf->conflict.size);

--- a/src/mcsat/uf/uf_plugin.c
+++ b/src/mcsat/uf/uf_plugin.c
@@ -380,17 +380,20 @@ void uf_plugin_propagate(plugin_t* plugin, trail_token_t* prop) {
       prop->conflict(prop);
       (*uf->stats.conflicts) ++;
       // extract terms used in the conflict
-      /* for (i = 0; i < weq->conflict.size; ++i) { */
-      /*   t = weq->conflict.data[i]; */
-      /*   if (term_kind(terms, t) == EQ_TERM) { */
-      /*     t_desc = eq_term_desc(terms, t); */
-      /*     int_mset_add(&weq->tmp, t_desc->arg[0]); */
-      /*     int_mset_add(&weq->tmp, t_desc->arg[1]); */
-      /*   } else { */
-      /*     assert(false); */
-      /*   } */
-      /* } */
-      /* weq_graph_bump_terms_and_reset(weq, &weq->tmp); */
+      term_table_t *terms = uf->ctx->terms;
+      composite_term_t* t_desc = NULL;
+      uint32_t i;
+      for (i = 0; i < uf->conflict.size; ++i) {
+        t = uf->conflict.data[i];
+        if (term_kind(terms, t) == EQ_TERM) {
+          t_desc = eq_term_desc(terms, t);
+          int_mset_add(&uf->tmp, t_desc->arg[0]);
+          int_mset_add(&uf->tmp, t_desc->arg[1]);
+        } else {
+          assert(false);
+        }
+      }
+      uf_plugin_bump_terms_and_reset(uf, &uf->tmp);
       statistic_avg_add(uf->stats.avg_conflict_size, uf->conflict.size);
     }
   }

--- a/src/mcsat/weq/weak_eq_graph.c
+++ b/src/mcsat/weq/weak_eq_graph.c
@@ -91,12 +91,12 @@ void weq_graph_pop(weq_graph_t* weq) {
 }
 
 void weq_graph_stats_init(weq_graph_t* weq) {
+  weq->stats.array_check_calls = statistics_new_int(weq->ctx->stats, "mcsat::uf::array_check_calls");
   weq->stats.array_terms = statistics_new_int(weq->ctx->stats, "mcsat::uf::array_terms");
   weq->stats.select_terms = statistics_new_int(weq->ctx->stats, "mcsat::uf::select_terms");
   weq->stats.array_update1_axioms = statistics_new_int(weq->ctx->stats, "mcsat::uf::array_update1_axioms");
   weq->stats.array_update2_axioms = statistics_new_int(weq->ctx->stats, "mcsat::uf::array_update2_axioms");
   weq->stats.array_ext_axioms = statistics_new_int(weq->ctx->stats, "mcsat::uf::array_ext_axioms");
-
 }
 
 // declaration
@@ -1321,8 +1321,12 @@ void weq_graph_check_array_conflict(weq_graph_t* weq, ivector_t* conflict) {
   (*weq->stats.select_terms) = select_terms.size;
 
   if (updates_present) {
-    if (USE_ARRAY_DIFF && ok) {
-      ok = weq_graph_array_ext_diff_check(weq, conflict, &array_eq_terms, NULL);
+    if (ok) {
+      (*weq->stats.array_check_calls) ++;
+
+      if (USE_ARRAY_DIFF) {
+	ok = weq_graph_array_ext_diff_check(weq, conflict, &array_eq_terms, NULL);
+      }
     }
 
     if (ok) {

--- a/src/mcsat/weq/weak_eq_graph.c
+++ b/src/mcsat/weq/weak_eq_graph.c
@@ -1313,7 +1313,7 @@ void weq_graph_check_array_conflict(weq_graph_t* weq, ivector_t* conflict) {
     if (!eq_graph_term_has_value(weq->eq_graph, select_terms.data[i]) ||
 	!eq_graph_term_has_value(weq->eq_graph, t_desc->arg[0]) ||
 	!eq_graph_term_has_value(weq->eq_graph, t_desc->arg[1])) {
-	ok = false;
+      ok = false;
     }
   }
 

--- a/src/mcsat/weq/weak_eq_graph.h
+++ b/src/mcsat/weq/weak_eq_graph.h
@@ -58,8 +58,8 @@ typedef struct weq_graph_s {
   /** Map: terms to fun_nodes */
   ptr_hmap_t fun_node_map;
 
-  /** Function Values to term (one rep term) */
-  int_hmap_t fun_val_term_map;
+  /** Value eq_node_id to term (one rep term) */
+  int_hmap_t val_id_term_map;
 
   /** Weak path equalities **/
   ivector_t path_cond;

--- a/src/mcsat/weq/weak_eq_graph.h
+++ b/src/mcsat/weq/weak_eq_graph.h
@@ -71,6 +71,7 @@ typedef struct weq_graph_s {
   ivector_t path_indices2;
 
   struct {
+    statistic_int_t* array_check_calls;
     statistic_int_t* array_terms;
     statistic_int_t* select_terms;
     statistic_int_t* array_update1_axioms;


### PR DESCRIPTION
updates the get_term_rep method -- needed for interpreted indices.

Order array terms for check the conflicts

array-solver-calls stats