### PR TITLE
Symbol table remove records fix

### DIFF
--- a/src/utils/symbol_tables.c
+++ b/src/utils/symbol_tables.c
@@ -526,6 +526,7 @@ void stbl_remove_records(stbl_t *sym_table, void *aux, stbl_filter_t f) {
         // keep r
         *q = r;
         q = &r->next;
+        r = p;
       }
     }
     *q = NULL;


### PR DESCRIPTION
When a record in a bucket is not removed, the `r` pointer is not updated, resulting in an infinite loop. 