### PR TITLE
use array const-like model for arrays

### DIFF
--- a/src/frontend/smt2/smt2_printer.c
+++ b/src/frontend/smt2/smt2_printer.c
@@ -607,17 +607,10 @@ void smt2_pp_def(smt2_pp_t *printer, value_table_t *table, const char *name, typ
   types = table->type_table;
   pp_open_block(&printer->pp, PP_OPEN_SMT2_DEF);
   smt2_pp_symbol(printer, name);
-  if (object_is_function(table, c)) {
-    smt2_pp_function_params(printer, types, tau);
-    smt2_pp_function_definition(printer, table, tau, c);
-  } else if (object_is_update(table, c)) {
-    smt2_pp_function_params(printer, types, tau);
-    smt2_pp_update_definition(printer, table, c);
-  } else {
-    pp_string(&printer->pp, "()");
-    smt2_pp_type(printer, types, tau);
-    smt2_pp_object_in_def(printer, table, tau, c);
-  }
+  pp_string(&printer->pp, "()");
+  smt2_pp_type(printer, types, tau);
+  smt2_pp_object_in_def(printer, table, tau, c);
+
   pp_close_block(&printer->pp, true);
 }
 

--- a/tests/regress/wd/example_mdl.smt2.gold
+++ b/tests/regress/wd/example_mdl.smt2.gold
@@ -1,6 +1,6 @@
 sat
 (model
-  (define-fun arr1 ((x!0 Int)) Bool false)
-  (define-fun arr2 ((x!0 Int)) Bool (ite (= x!0 10) true false)))
+  (define-fun arr1 () (Array Int Bool) ((as const (Array Int Bool)) false))
+  (define-fun arr2 () (Array Int Bool) (store ((as const (Array Int Bool)) false) 10 true)))
 ((arr1 ((as const (Array Int Bool)) false))
  (arr2 (store ((as const (Array Int Bool)) false) 10 true)))


### PR DESCRIPTION
Updates array model printing according to the SMTLIB format.