### PR TITLE
fix mingw strerror_r issue

### DIFF
--- a/src/utils/error.c
+++ b/src/utils/error.c
@@ -30,7 +30,12 @@ void perror_fatal(const char *s) {
 void perror_fatal_code(const char *s, int err) {
   char buffer[64];
   
+#ifdef MINGW
+  fprintf(stderr, "%s: %s\n", s, strerror(err));
+  exit(YICES_EXIT_INTERNAL_ERROR);
+#else
   strerror_r(err, buffer, sizeof(buffer));
   fprintf(stderr, "%s: %s\n", s, buffer);
   exit(YICES_EXIT_INTERNAL_ERROR);
+#endif
 }

--- a/src/utils/error.c
+++ b/src/utils/error.c
@@ -32,10 +32,10 @@ void perror_fatal_code(const char *s, int err) {
   
 #ifdef MINGW
   fprintf(stderr, "%s: %s\n", s, strerror(err));
-  exit(YICES_EXIT_INTERNAL_ERROR);
 #else
   strerror_r(err, buffer, sizeof(buffer));
   fprintf(stderr, "%s: %s\n", s, buffer);
-  exit(YICES_EXIT_INTERNAL_ERROR);
 #endif
+
+  exit(YICES_EXIT_INTERNAL_ERROR);
 }


### PR DESCRIPTION
strerror_r is not available under windows.

This PR fixes this by using strerror (thread safe under windows) 