### PR TITLE
fix mingw timeout error

### DIFF
--- a/src/utils/timeout.c
+++ b/src/utils/timeout.c
@@ -76,7 +76,7 @@ typedef struct timeout_s {
   timeout_state_t state;
   timeout_handler_t handler;
   void *param;
-#ifdef THREAD_SAFE
+#if !defined(MINGW) && defined(THREAD_SAFE)
   struct timespec ts;
   pthread_t thread;
   pthread_mutex_t mutex;
@@ -84,14 +84,11 @@ typedef struct timeout_s {
 #endif
 } timeout_t;
 
-#ifndef THREAD_SAFE
-
 /*
  * Global structure common to both implementation.
  */
 static timeout_t the_timeout;
 
-#endif
 
 #ifndef MINGW
 

--- a/src/utils/timeout.c
+++ b/src/utils/timeout.c
@@ -84,10 +84,15 @@ typedef struct timeout_s {
 #endif
 } timeout_t;
 
+
+#if !defined(THREAD_SAFE) || defined(MINGW)
+
 /*
  * Global structure common to both implementation.
  */
 static timeout_t the_timeout;
+
+#endif
 
 
 #ifndef MINGW


### PR DESCRIPTION
- fix pthread issue for ming

- the_timeout variable is used by the mingw implementation, which is not declared if THREAD_SAFE is not defined. However,  it is needed for mingw. (this was changed in the recent PR about thread safety)

