### PR TITLE
Rename smt status enum

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -4539,23 +4539,23 @@ if (code < 0) {
 }
 
 switch (yices_check_context(ctx, NULL)) {
-case STATUS_SAT:
+case SMT_STATUS_SAT:
   printf("The formula is satisfiable\n");
   ...
   break;
 
- case STATUS_UNSAT:
+ case SMT_STATUS_UNSAT:
    printf("The formula is not satisfiable\n");
    break;
 
- case STATUS_UNKNOWN:
+ case SMT_STATUS_UNKNOWN:
    printf("The status is unknown\n");
    break;
 
- case STATUS_IDLE:
- case STATUS_SEARCHING:
- case STATUS_INTERRUPTED:
- case STATUS_ERROR:
+ case SMT_STATUS_IDLE:
+ case SMT_STATUS_SEARCHING:
+ case SMT_STATUS_INTERRUPTED:
+ case SMT_STATUS_ERROR:
    fprintf(stderr, "Error in check_context\n");
    yices_print_error(stderr);
    break;
@@ -4570,8 +4570,8 @@ case STATUS_SAT:
 
 \subsection*{Building and Querying a Model}
 
-If \texttt{yices\_check\_context} returns \texttt{STATUS\_SAT} (or
-\texttt{STATUS\_UNKNOWN}), then we can construct a model of the
+If \texttt{yices\_check\_context} returns \texttt{SMT\_STATUS\_SAT} (or
+\texttt{SMT\_STATUS\_UNKNOWN}), then we can construct a model of the
 asserted formulas as shown in Figure~\ref{model-query}. The code also
 shows how to print the model and how to evaluate the value of terms in
 a model.

--- a/doc/sphinx/source/_static/example1.c
+++ b/doc/sphinx/source/_static/example1.c
@@ -86,7 +86,7 @@ static void simple_test(void) {
   }
 
   switch (yices_check_context(ctx, NULL)) { // call check_context, NULL means 'use default heuristics'
-  case STATUS_SAT:
+  case SMT_STATUS_SAT:
     printf("The formula is satisfiable\n");
     model_t* model = yices_get_model(ctx, true);  // get the model
     if (model == NULL) {
@@ -117,18 +117,18 @@ static void simple_test(void) {
     }
     break;
       
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     printf("The formula is not satisfiable\n");
     break;
 
-  case STATUS_UNKNOWN:
+  case SMT_STATUS_UNKNOWN:
     printf("The status is unknown\n");
     break;
 
-  case STATUS_IDLE:
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
-  case STATUS_ERROR:
+  case SMT_STATUS_IDLE:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
+  case SMT_STATUS_ERROR:
     fprintf(stderr, "Error in check_context\n");
     yices_print_error(stderr);
     break;

--- a/doc/sphinx/source/_static/example1b.c
+++ b/doc/sphinx/source/_static/example1b.c
@@ -93,7 +93,7 @@ static void simple_test(void) {
   }
 
   switch (yices_check_context(ctx, NULL)) { // call check_context, NULL means 'use default heuristics'
-  case STATUS_SAT:
+  case SMT_STATUS_SAT:
     printf("The formula is satisfiable\n");
     model = yices_get_model(ctx, 1);  // get the model
     if (model == NULL) {
@@ -125,18 +125,18 @@ static void simple_test(void) {
     }
     break;
       
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     printf("The formula is not satisfiable\n");
     break;
 
-  case STATUS_UNKNOWN:
+  case SMT_STATUS_UNKNOWN:
     printf("The status is unknown\n");
     break;
 
-  case STATUS_IDLE:
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
-  case STATUS_ERROR:
+  case SMT_STATUS_IDLE:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
+  case SMT_STATUS_ERROR:
     fprintf(stderr, "Error in check_context\n");
     yices_print_error(stderr);
     break;

--- a/doc/sphinx/source/api-types.rst
+++ b/doc/sphinx/source/api-types.rst
@@ -421,29 +421,29 @@ Contexts
    Context state::
 
      typedef enum smt_status {
-       STATUS_IDLE,
-       STATUS_SEARCHING,
-       STATUS_UNKNOWN,
-       STATUS_SAT,
-       STATUS_UNSAT,
-       STATUS_INTERRUPTED,
-       STATUS_ERROR
+       SMT_STATUS_IDLE,
+       SMT_STATUS_SEARCHING,
+       SMT_STATUS_UNKNOWN,
+       SMT_STATUS_SAT,
+       SMT_STATUS_UNSAT,
+       SMT_STATUS_INTERRUPTED,
+       SMT_STATUS_ERROR
      } smt_status_t;
 
    The type :c:type:`smt_status_t` enumerates the possible states of a
    context. It is also the type returned by the function that checks
    whether a context is satisfiable. The following codes are defined:
 
-   .. c:enum:: STATUS_IDLE
+   .. c:enum:: SMT_STATUS_IDLE
 
       Initial context state.
 
       In this state, it is possible to assert formulas in the context.
-      After assertions, the state may change to :c:enum:`STATUS_UNSAT` if
+      After assertions, the state may change to :c:enum:`SMT_STATUS_UNSAT` if
       the assertions are trivially unsatisfiable. Otherwise, the state
-      remains :c:enum:`STATUS_IDLE`.
+      remains :c:enum:`SMT_STATUS_IDLE`.
 
-   .. c:enum:: STATUS_SEARCHING
+   .. c:enum:: SMT_STATUS_SEARCHING
 
       State during search.
 
@@ -451,18 +451,18 @@ Contexts
       :c:func:`yices_check_context`.  It remains in this state until
       either the solver completes or the search is interrupted.
       
-   .. c:enum:: STATUS_UNKNOWN
+   .. c:enum:: SMT_STATUS_UNKNOWN
 
       State entered when the search terminates but is inconclusive.
 
       This may happen if the context's solver is not complete for the specific
       logic used. For example, the logic may have quantifiers.
 
-   .. c:enum:: STATUS_SAT
+   .. c:enum:: SMT_STATUS_SAT
 
       State entered when the search terminates and the assertions are satisfiable.
 
-   .. c:enum:: STATUS_UNSAT
+   .. c:enum:: SMT_STATUS_UNSAT
 
       State entered when the assertions are known to be unsatisfiable.
 
@@ -470,15 +470,15 @@ Contexts
       asserted (if the inconsistency is detected by formula
       simplification), or when the search terminates.
 
-   .. c:enum:: STATUS_INTERRUPTED
+   .. c:enum:: SMT_STATUS_INTERRUPTED
 
       State entered when the search is interrupted.
 
-      When a context is in the state :c:enum:`STATUS_SEARCHING` then the search
+      When a context is in the state :c:enum:`SMT_STATUS_SEARCHING` then the search
       can be interrupted through a call to :c:func:`yices_stop_search`. This
-      moves the context's state to :c:enum:`STATUS_INTERRUPTED`.
+      moves the context's state to :c:enum:`SMT_STATUS_INTERRUPTED`.
 
-   .. c:enum:: STATUS_ERROR
+   .. c:enum:: SMT_STATUS_ERROR
 
       This is an error code. It is returned by functions that operate on a
       context when the operation cannot be performed.

--- a/doc/sphinx/source/basic-usage.rst
+++ b/doc/sphinx/source/basic-usage.rst
@@ -139,23 +139,23 @@ context, assert ``f`` in this context, then call function :c:func:`yices_check_c
   }
 
   switch (yices_check_context(ctx, NULL)) {
-  case STATUS_SAT:
+  case SMT_STATUS_SAT:
     printf("The formula is satisfiable\n");
     ...
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     printf("The formula is not satisfiable\n");
     break;
 
-  case STATUS_UNKNOWN:
+  case SMT_STATUS_UNKNOWN:
     printf("The status is unknown\n");
     break;
 
-  case STATUS_IDLE:
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
-  case STATUS_ERROR:
+  case SMT_STATUS_IDLE:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
+  case SMT_STATUS_ERROR:
     fprintf(stderr, "Error in check_context\n");
     yices_print_error(stderr);
     break;
@@ -167,11 +167,11 @@ function :c:func:`yices_assert_formula` asserts a formula in the
 context. Function :c:func:`yices_check_context` returns a code of type
 :c:type:`smt_status_t`:
  
-   - :c:enum:`STATUS_SAT` means that the context is satisfiable.
+   - :c:enum:`SMT_STATUS_SAT` means that the context is satisfiable.
 
-   - :c:enum:`STATUS_UNSAT` means that the context is not satisfiable.
+   - :c:enum:`SMT_STATUS_UNSAT` means that the context is not satisfiable.
 
-   - :c:enum:`STATUS_UNKNOWN` means that the context's status could
+   - :c:enum:`SMT_STATUS_UNKNOWN` means that the context's status could
      not be determined.
 
 Other codes are error conditions.
@@ -183,8 +183,8 @@ Once the context ``ctx`` is no longer needed, we delete it using :c:func:`yices_
 Building and Querying a Model
 -----------------------------
 
-If :c:func:`yices_check_context` returns :c:data:`STATUS_SAT` (or
-:c:data:`STATUS_UNKNOWN`), we can construct a model of the asserted
+If :c:func:`yices_check_context` returns :c:data:`SMT_STATUS_SAT` (or
+:c:data:`SMT_STATUS_UNKNOWN`), we can construct a model of the asserted
 formulas by calling :c:func:`yices_get_model`. We then display the
 model using :c:func:`yices_pp_model`::
 

--- a/doc/sphinx/source/context-operations.rst
+++ b/doc/sphinx/source/context-operations.rst
@@ -533,24 +533,24 @@ assert formulas, check satisfiability, and query the context's status.
 
    The returned value is one of the following codes:
 
-   - :c:enum:`STATUS_IDLE`. This is the initial state.
+   - :c:enum:`SMT_STATUS_IDLE`. This is the initial state.
 
      In this state, it is possible to assert formulas. The state may
-     then change to :c:enum:`STATUS_UNSAT` if the assertions are
+     then change to :c:enum:`SMT_STATUS_UNSAT` if the assertions are
      trivially unsatisfiable Otherwise, the state remains
-     :c:enum:`STATUS_IDLE`.
+     :c:enum:`SMT_STATUS_IDLE`.
 
-   - :c:enum:`STATUS_SEARCHING`. This is the context state during search.
+   - :c:enum:`SMT_STATUS_SEARCHING`. This is the context state during search.
 
      The context enters this state on a call to :c:func:`yices_check_context` and remains
      in this state until the solver completes or the search is interrupted.
 
-   - :c:enum:`STATUS_SAT`, :c:enum:`STATUS_UNSAT`, :c:enum:`STATUS_UNKNOWN`.
+   - :c:enum:`SMT_STATUS_SAT`, :c:enum:`SMT_STATUS_UNSAT`, :c:enum:`SMT_STATUS_UNKNOWN`.
 
-     These are the states after a search completes. :c:enum:`STATUS_UNKNOWN` means
+     These are the states after a search completes. :c:enum:`SMT_STATUS_UNKNOWN` means
      that the search was inconclusive, which may happen if the solver is not complete.
 
-   - :c:enum:`STATUS_INTERRUPTED`.
+   - :c:enum:`SMT_STATUS_INTERRUPTED`.
 
      This state is entered if a search is interrupted.
 
@@ -566,17 +566,17 @@ assert formulas, check satisfiability, and query the context's status.
    The term *t* must be Boolean.
 
    The context *ctx* must be in one of the following states:
-   :c:enum:`STATUS_IDLE`, :c:enum:`STATUS_UNSAT`,
-   :c:enum:`STATUS_SAT`, or :c:enum:`STATUS_UNKNOWN`.
+   :c:enum:`SMT_STATUS_IDLE`, :c:enum:`SMT_STATUS_UNSAT`,
+   :c:enum:`SMT_STATUS_SAT`, or :c:enum:`SMT_STATUS_UNKNOWN`.
 
-   - if the current state is :c:enum:`STATUS_UNSAT`, this function does nothing.
+   - if the current state is :c:enum:`SMT_STATUS_UNSAT`, this function does nothing.
 
    - otherwise, the formula *t* is simplified and asserted in the context. The context's state
-     is then changed to :c:enum:`STATUS_UNSAT` if the assertion simplifies to false, or to
-     :c:enum:`STATUS_IDLE` otherwise.
+     is then changed to :c:enum:`SMT_STATUS_UNSAT` if the assertion simplifies to false, or to
+     :c:enum:`SMT_STATUS_IDLE` otherwise.
 
    If the context is in mode *one-shot*, this function fails if the state is either
-   :c:enum:`STATUS_SAT` or :c:enum:`STATUS_UNKNOWN`.
+   :c:enum:`SMT_STATUS_SAT` or :c:enum:`SMT_STATUS_UNKNOWN`.
 
    The function returns 0 if there's no error, or -1 otherwise.
 
@@ -596,11 +596,11 @@ assert formulas, check satisfiability, and query the context's status.
 
      -- type1 := bool
 
-   - if *ctx*'s state is :c:enum:`STATUS_INTERRUPTED`
+   - if *ctx*'s state is :c:enum:`SMT_STATUS_INTERRUPTED`
 
      -- error code: :c:enum:`CTX_INVALID_OPERATION`
 
-   - if *ctx*'s mode is *one-shot* and *ctx*'s state is neither :c:enum:`STATUS_IDLE` nor :c:enum:`STATUS_UNSAT`
+   - if *ctx*'s mode is *one-shot* and *ctx*'s state is neither :c:enum:`SMT_STATUS_IDLE` nor :c:enum:`SMT_STATUS_UNSAT`
 
      -- error code: :c:enum:`CTX_OPERATION_NOT_SUPPORTED`
 
@@ -620,9 +620,9 @@ assert formulas, check satisfiability, and query the context's status.
 
    - *t* must be an array of *n* Boolean terms.
 
-   The context must be in state :c:enum:`STATUS_IDLE`,
-   :c:enum:`STATUS_UNSAT`, :c:enum:`STATUS_SAT`, or
-   :c:enum:`STATUS_UNKNOWN`.
+   The context must be in state :c:enum:`SMT_STATUS_IDLE`,
+   :c:enum:`SMT_STATUS_UNSAT`, :c:enum:`SMT_STATUS_SAT`, or
+   :c:enum:`SMT_STATUS_UNKNOWN`.
 
    This function is equivalent to calling
    :c:func:`yices_assert_formula` with input *(and t[0] ... t[n-1])*.
@@ -649,10 +649,10 @@ assert formulas, check satisfiability, and query the context's status.
 
    This function's behavior and returned value depend on *ctx*'s current state.
 
-   - If the state is :c:enum:`STATUS_SAT`, :c:enum:`STATUS_UNSAT`, or :c:enum:`STATUS_UNKNOWN`,
+   - If the state is :c:enum:`SMT_STATUS_SAT`, :c:enum:`SMT_STATUS_UNSAT`, or :c:enum:`SMT_STATUS_UNKNOWN`,
      the function just returns this status.
 
-   - If the state is :c:enum:`STATUS_IDLE`, then the context's solver
+   - If the state is :c:enum:`SMT_STATUS_IDLE`, then the context's solver
      (as defined by the context's configuration) searches for a
      satisfying assignment to all the assertions stored in *ctx*.
      If *params* is not :c:macro:`NULL`, the solver uses the
@@ -660,25 +660,25 @@ assert formulas, check satisfiability, and query the context's status.
 
      Then the function returns one of the following codes:
 
-     - :c:enum:`STATUS_UNSAT`: the context is not satisfiable.
+     - :c:enum:`SMT_STATUS_UNSAT`: the context is not satisfiable.
 
-     - :c:enum:`STATUS_SAT`: the context is satisfiable.
+     - :c:enum:`SMT_STATUS_SAT`: the context is satisfiable.
 
-     - :c:enum:`STATUS_UNKNOWN`: the solver can't prove whether the context is
+     - :c:enum:`SMT_STATUS_UNKNOWN`: the solver can't prove whether the context is
        satisfiable or not.
 
-     - :c:enum:`STATUS_INTERRUPTED`: the search was interrupted by a
+     - :c:enum:`SMT_STATUS_INTERRUPTED`: the search was interrupted by a
        call to :c:func:`yices_stop_search`.
 
      This returned value is also stored as the context's status flag, with the following exception:
 
      - If the context is configured for mode *interactive* and the search is interrupted,
-       then the function returns :c:enum:`STATUS_INTERRUPTED` but the context's state is
+       then the function returns :c:enum:`SMT_STATUS_INTERRUPTED` but the context's state is
        restored to what it was before the call to :c:func:`yices_check_context`, and the
-       internal status flag is reset to  :c:enum:`STATUS_IDLE`.
+       internal status flag is reset to  :c:enum:`SMT_STATUS_IDLE`.
 
    - If *ctx* is in another state, the function
-     returns :c:enum:`STATUS_ERROR`.
+     returns :c:enum:`SMT_STATUS_ERROR`.
 
    **Error report**
 
@@ -693,12 +693,12 @@ assert formulas, check satisfiability, and query the context's status.
 
    This function can be called from a signal handler to stop the
    search after at call to :c:func:`yices_check_context`. If the
-   context's state is :c:enum:`STATUS_SEARCHING` then the search is
+   context's state is :c:enum:`SMT_STATUS_SEARCHING` then the search is
    interrupted, otherwise the function does nothing.
 
    .. note:: If the search is interrupted and the context's mode is
              not *interactive* then the context's enters state
-             :c:enum:`STATUS_INTERRUPTED`. The only way to recover is
+             :c:enum:`SMT_STATUS_INTERRUPTED`. The only way to recover is
              then to call :c:func:`yices_reset_context` or
              :c:func:`yices_pop` (assuming the context supports push and pop).
 
@@ -708,7 +708,7 @@ assert formulas, check satisfiability, and query the context's status.
    Resets a context.
 
    This function removes all the assertions stored in *ctx* and resets
-   the context's state to :c:enum:`STATUS_IDLE`.
+   the context's state to :c:enum:`SMT_STATUS_IDLE`.
 
 
 .. c:function:: int32_t yices_assert_blocking_clause(context_t* ctx)
@@ -718,19 +718,19 @@ assert formulas, check satisfiability, and query the context's status.
    This function is intended to enumerate different models for a set
    of assertions.
 
-   - If *ctx*'s status is either :c:enum:`STATUS_SAT` or
-     :c:enum:`STATUS_UNKNOWN`, then a new clause is asserted in *ctx*
+   - If *ctx*'s status is either :c:enum:`SMT_STATUS_SAT` or
+     :c:enum:`SMT_STATUS_UNKNOWN`, then a new clause is asserted in *ctx*
      to remove the current truth assignment.  After this clause is
      added, the next call to :c:func:`yices_check_context` will either
      produce a different truth assignment (hence a different model) or
-     return :c:enum:`STATUS_UNSAT`.
+     return :c:enum:`SMT_STATUS_UNSAT`.
 
      After adding the clause, the context's state is updated to either
-     :c:enum:`STATUS_IDLE` (if the clause is not empty) or to
-     :c:enum:`STATUS_UNSAT` if the blocking clause is empty.
+     :c:enum:`SMT_STATUS_IDLE` (if the clause is not empty) or to
+     :c:enum:`SMT_STATUS_UNSAT` if the blocking clause is empty.
 
 
-   - If *ctx*'s status is not :c:enum:`STATUS_SAT` or :c:enum:`STATUS_UNKNOWN`,
+   - If *ctx*'s status is not :c:enum:`SMT_STATUS_SAT` or :c:enum:`SMT_STATUS_UNKNOWN`,
      the function reports an error.
 
    This function is not supported if the context's mode is *one-shot*.
@@ -739,7 +739,7 @@ assert formulas, check satisfiability, and query the context's status.
 
    **Error report**
 
-   - if *ctx*'s status is different from :c:enum:`STATUS_SAT` and :c:enum:`STATUS_UNKNOWN`
+   - if *ctx*'s status is different from :c:enum:`SMT_STATUS_SAT` and :c:enum:`SMT_STATUS_UNKNOWN`
 
      -- error code: :c:enum:`CTX_INVALID_OPERATION`
 
@@ -770,8 +770,8 @@ be removed by :c:func:`yices_pop`.
 
    This function starts a new assertion level. The *ctx* must be
    configured to support push and pop, and its state must be either
-   :c:enum:`STATUS_IDLE`, or :c:enum:`STATUS_SAT`, or
-   :c:enum:`STATUS_UNKNOWN`.
+   :c:enum:`SMT_STATUS_IDLE`, or :c:enum:`SMT_STATUS_SAT`, or
+   :c:enum:`SMT_STATUS_UNKNOWN`.
 
    The function returns 0 if the operation succeeds or -1 otherwise.
 
@@ -781,8 +781,8 @@ be removed by :c:func:`yices_pop`.
 
      -- error code: :c:enum:`CTX_OPERATION_NOT_SUPPORTED`
 
-   - if *ctx* supports push and pop but its status is :c:enum:`STATUS_UNSAT`,
-     :c:enum:`STATUS_SEARCHING`, or :c:enum:`STATUS_INTERRUPTED`:
+   - if *ctx* supports push and pop but its status is :c:enum:`SMT_STATUS_UNSAT`,
+     :c:enum:`SMT_STATUS_SEARCHING`, or :c:enum:`SMT_STATUS_INTERRUPTED`:
 
      -- error code: :c:enum:`CTX_INVALID_OPERATION`
 
@@ -803,7 +803,7 @@ be removed by :c:func:`yices_pop`.
 
      -- error code: :c:enum:`CTX_OPERATION_NOT_SUPPORTED`
 
-   - if *ctx*'s status is :c:enum:`STATUS_SEARCHING` or if the assertion level is zero:
+   - if *ctx*'s status is :c:enum:`SMT_STATUS_SEARCHING` or if the assertion level is zero:
 
      -- error code: :c:enum:`CTX_INVALID_OPERATION`
 
@@ -862,26 +862,26 @@ distribution.
    The function checks whether all assertions currently asserted in *ctx*
    together with the *n* assumptions *t[0]* |...| *t[n-1]* are
    satisfiable, and returns the result as a status code. If the
-   function returns :c:enum:`STATUS_UNSAT` then one can compute an
+   function returns :c:enum:`SMT_STATUS_UNSAT` then one can compute an
    unsat core (i.e., a subset of the assumptions that is
    unsatisfiable) by calling :c:func:`yices_get_unsat_core`.
 
    More precisely:
 
-   - If *ctx*'s current status is :c:enum:`STATUS_UNSAT` then the function does nothing
-     and returns :c:enum:`STATUS_UNSAT`.
+   - If *ctx*'s current status is :c:enum:`SMT_STATUS_UNSAT` then the function does nothing
+     and returns :c:enum:`SMT_STATUS_UNSAT`.
 
-   - If *ctx*'s status is :c:enum:`STATUS_IDLE`, :c:enum:`STATUS_SAT`,
-     or :c:enum:`STATUS_UNKNOWN` then the function checks whether *ctx* conjoined
+   - If *ctx*'s status is :c:enum:`SMT_STATUS_IDLE`, :c:enum:`SMT_STATUS_SAT`,
+     or :c:enum:`SMT_STATUS_UNKNOWN` then the function checks whether *ctx* conjoined
      with the *n* assumptions is satisfiable. This is done even if *n* is zero.
      The function will then return a code as in :c:func:`yices_check_context`.
 
-   - If *ctx*'s status is anything else, the function returns :c:enum:`STATUS_ERROR`.
+   - If *ctx*'s status is anything else, the function returns :c:enum:`SMT_STATUS_ERROR`.
 
 
-   This operation fails and returns :c:enum:`STATUS_ERROR` if *ctx* is
+   This operation fails and returns :c:enum:`SMT_STATUS_ERROR` if *ctx* is
    configured for one-shot solving and *ctx*'s status is anything
-   other than :c:enum:`STATUS_IDLE`.
+   other than :c:enum:`SMT_STATUS_IDLE`.
 
    **Error report**
 
@@ -906,7 +906,7 @@ distribution.
    - *v* must be an initialized term vector (see :c:func:`yices_init_term_vector`).
 
    The function checks whether *ctx*'s status is
-   :c:enum:`STATUS_UNSAT`. If so, it computes and unsat core and store
+   :c:enum:`SMT_STATUS_UNSAT`. If so, it computes and unsat core and store
    it in vector *v*. The unsat core is an subset of the assumptions
    passed to the most recent call to :c:func:`yices_check_context_with_assumptions`.
 
@@ -923,12 +923,12 @@ distribution.
      There are no duplicates in the *v->data* array.
 
 
-   If *ctx*'s status is anything other than :c:enum:`STATUS_UNSAT`,
+   If *ctx*'s status is anything other than :c:enum:`SMT_STATUS_UNSAT`,
    the function leaves *v* unchanged and returns -1.
 
    **Error report**
 
-   - If *ctx*'s status is not :c:enum:`STATUS_UNSAT`
+   - If *ctx*'s status is not :c:enum:`SMT_STATUS_UNSAT`
 
      -- error code: :c:enum:`CTX_INVALID_OPERATION`
 
@@ -1001,21 +1001,21 @@ yices_set_config). This model interpolant is constructed by calling
 
    More precisely:
 
-   - If *ctx*'s current status is :c:enum:`STATUS_UNSAT` then the function does nothing
-     and returns :c:enum:`STATUS_UNSAT`.
+   - If *ctx*'s current status is :c:enum:`SMT_STATUS_UNSAT` then the function does nothing
+     and returns :c:enum:`SMT_STATUS_UNSAT`.
 
-   - If *ctx*'s status is :c:enum:`STATUS_IDLE`, :c:enum:`STATUS_SAT`,
-     or :c:enum:`STATUS_UNKNOWN` then the function checks whether
+   - If *ctx*'s status is :c:enum:`SMT_STATUS_IDLE`, :c:enum:`SMT_STATUS_SAT`,
+     or :c:enum:`SMT_STATUS_UNKNOWN` then the function checks whether
      *ctx* conjoined with the *n* equalities given by *mdl* and *t* is
      satisfiable. This is done even if *n* is zero.  The function will
      then return a code as in :c:func:`yices_check_context`.
 
-   - If *ctx*'s status is anything else, the function returns :c:enum:`STATUS_ERROR`.
+   - If *ctx*'s status is anything else, the function returns :c:enum:`SMT_STATUS_ERROR`.
 
 
-   This operation fails and returns :c:enum:`STATUS_ERROR` if *ctx* is
+   This operation fails and returns :c:enum:`SMT_STATUS_ERROR` if *ctx* is
    configured for one-shot solving and *ctx*'s status is anything
-   other than :c:enum:`STATUS_IDLE`.
+   other than :c:enum:`SMT_STATUS_IDLE`.
 
    **Error report**
 
@@ -1027,7 +1027,7 @@ yices_set_config). This model interpolant is constructed by calling
 
      -- error code: :c:enum:`CTX_OPERATION_NOT_SUPPORTED`
 
-   - If the resulting status is :c:enum:`STATUS_SAT` and context does not support multichecks:
+   - If the resulting status is :c:enum:`SMT_STATUS_SAT` and context does not support multichecks:
 
      -- error code: :c:enum:`CTX_OPERATION_NOT_SUPPORTED`
 
@@ -1046,7 +1046,7 @@ yices_set_config). This model interpolant is constructed by calling
 
    This is intended to be used after a call to
    :c:func:`yices_check_context_with_model` that returned
-   :c:enum:`STATUS_UNSAT`. In this case, the function builds an model
+   :c:enum:`SMT_STATUS_UNSAT`. In this case, the function builds an model
    interpolant. The model interpolant is a clause implied by the
    current context that is false in the model provides to
    :c:func:`yices_check_context_with_model`.
@@ -1057,7 +1057,7 @@ yices_set_config). This model interpolant is constructed by calling
 
      -- error code: :c:enum:`CTX_OPERATION_NOT_SUPPORTED`
 
-   - If the context's status is not :c:enum:`STATUS_UNSAT`:
+   - If the context's status is not :c:enum:`SMT_STATUS_UNSAT`:
 
      -- error code: :c:enum:`CTX_INVALID_OPERATION`
 
@@ -1100,10 +1100,10 @@ as follows::
 
    - *ctx->ctx_B* can be another context (not necessarily with MCSAT support).
 
-   If this function returns :c:enum:`STATUS_UNSAT`, then an
+   If this function returns :c:enum:`SMT_STATUS_UNSAT`, then an
    interpolant is returned in *ctx->interpolant*.
 
-   If this function returns :c:enum:`STATUS_SAT` and *build_model* is
+   If this function returns :c:enum:`SMT_STATUS_SAT` and *build_model* is
    true, then a model is returned in *ctx->model*. This model must be
    freed when no-longer needed by calling :c:func:`yices_free_model`.
 

--- a/doc/sphinx/source/formula-operations.rst
+++ b/doc/sphinx/source/formula-operations.rst
@@ -31,9 +31,9 @@ third-party Boolean satisfiability solvers for bit-vector problems.
 
    Check satisfiability of formula *f*
 
-   This returns :c:enum:`STATUS_SAT` if *f* is satisfiable,
-   :c:enum:`STATUS_UNSAT` if *f* is not satisfiable,
-   or :c:enum:`STATUS_ERROR` if there is an error.
+   This returns :c:enum:`SMT_STATUS_SAT` if *f* is satisfiable,
+   :c:enum:`SMT_STATUS_UNSAT` if *f* is not satisfiable,
+   or :c:enum:`SMT_STATUS_ERROR` if there is an error.
 
    **Parameters**
 
@@ -92,7 +92,7 @@ third-party Boolean satisfiability solvers for bit-vector problems.
 
     model_t *result;
     smt_status_t status = yices_check_formula(f, "QF_LRA", &result, NULL);
-    if (status == STATUS_SAT) {
+    if (status == SMT_STATUS_SAT) {
        // a model is returned in result
        yices_pp_model(stdout, result, 100, 100, 0);
        ...
@@ -198,7 +198,7 @@ to DIMACS cannot be performed as no CNF is constructed.
 The following two functions process formulas in the QF_BV logic. They
 first perform preprocessing and simplification. If the formulas are
 solved by this preprocessing, the functions return the status (either
-:c:enum:`STATUS_SAT` or :c:enum:`STATUS_UNSAT`). Otherwise, the
+:c:enum:`SMT_STATUS_SAT` or :c:enum:`SMT_STATUS_UNSAT`). Otherwise, the
 functions construct a CNF formula and write it to a file. Optionally,
 the functions can perform an extra round of simplification to the CNF
 formula before exporting it.

--- a/doc/sphinx/source/model-operations.rst
+++ b/doc/sphinx/source/model-operations.rst
@@ -37,7 +37,7 @@ Model Construction
    - *keep_subst*: flag to indicates whether the model should include
      eliminated variables
 
-   The context's status must be either :c:enum:`STATUS_SAT` or :c:enum:`STATUS_UNKNOWN`.
+   The context's status must be either :c:enum:`SMT_STATUS_SAT` or :c:enum:`SMT_STATUS_UNKNOWN`.
 
    When assertions are added to a context, the simplification
    procedures may eliminate variables by substitution (see
@@ -54,7 +54,7 @@ Model Construction
 
    **Error report**
 
-   - if *ctx*'s status is not :c:enum:`STATUS_SAT` or :c:enum:`STATUS_UNKNOWN`
+   - if *ctx*'s status is not :c:enum:`SMT_STATUS_SAT` or :c:enum:`SMT_STATUS_UNKNOWN`
 
      -- error code: :c:enum:`CTX_INVALID_OPERATION`
 
@@ -147,7 +147,7 @@ Model Construction
    Here is an example use of this function::
 
       yices_assert_formula(ctx, f);
-      if (yices_check(ctx, ...) == STATUS_SAT) {
+      if (yices_check(ctx, ...) == SMT_STATUS_SAT) {
          term_vector_t v;
          model_t *m = yices_get_model(ctx, true);
 	 yices_init_term_vector(&v);

--- a/examples/check_formula_examples.c
+++ b/examples/check_formula_examples.c
@@ -49,11 +49,11 @@ static void test(const char *delegate) {
       show_formulas(n);
       status = yices_check_formulas(formula, n, "QF_BV", &model, delegate);
       switch (status) {
-      case STATUS_UNSAT:
+      case SMT_STATUS_UNSAT:
 	printf("unsat\n");
 	break;
 
-      case STATUS_SAT:
+      case SMT_STATUS_SAT:
 	printf("sat\n");
 	printf("model:\n  ");
 	yices_pp_model(stdout, model, 100, 120, 2);

--- a/examples/check_formula_examples_mt.c
+++ b/examples/check_formula_examples_mt.c
@@ -56,11 +56,11 @@ static void test(term_t* formula, uint32_t nformula, const char *delegate) {
       show_formulas(formula, n);
       status = yices_check_formulas(formula, n, "QF_BV", &model, delegate);
       switch (status) {
-      case STATUS_UNSAT:
+      case SMT_STATUS_UNSAT:
         printf("unsat\n");
         break;
 
-      case STATUS_SAT:
+      case SMT_STATUS_SAT:
         printf("sat\n");
         printf("model:\n  ");
         yices_pp_model(stdout, model, 100, 120, 2);

--- a/examples/example1.c
+++ b/examples/example1.c
@@ -104,7 +104,7 @@ static void simple_test(void) {
   }
 
   switch (yices_check_context(ctx, NULL)) { // call check_context, NULL means 'use default heuristics'
-  case STATUS_SAT:
+  case SMT_STATUS_SAT:
     printf("The formula is satisfiable\n");
     model_t* model = yices_get_model(ctx, true);  // get the model
     if (model == NULL) {
@@ -135,18 +135,18 @@ static void simple_test(void) {
     }
     break;
       
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     printf("The formula is not satisfiable\n");
     break;
 
-  case STATUS_UNKNOWN:
+  case SMT_STATUS_UNKNOWN:
     printf("The status is unknown\n");
     break;
 
-  case STATUS_IDLE:
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
-  case STATUS_ERROR:
+  case SMT_STATUS_IDLE:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
+  case SMT_STATUS_ERROR:
     fprintf(stderr, "Error in check_context\n");
     yices_print_error(stderr);
     break;

--- a/examples/example1b.c
+++ b/examples/example1b.c
@@ -115,7 +115,7 @@ static void simple_test(void) {
   }
 
   switch (yices_check_context(ctx, NULL)) { // call check_context, NULL means 'use default heuristics'
-  case STATUS_SAT:
+  case SMT_STATUS_SAT:
     printf("The formula is satisfiable\n");
     model = yices_get_model(ctx, 1);  // get the model
     if (model == NULL) {
@@ -147,18 +147,18 @@ static void simple_test(void) {
     }
     break;
       
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     printf("The formula is not satisfiable\n");
     break;
 
-  case STATUS_UNKNOWN:
+  case SMT_STATUS_UNKNOWN:
     printf("The status is unknown\n");
     break;
 
-  case STATUS_IDLE:
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
-  case STATUS_ERROR:
+  case SMT_STATUS_IDLE:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
+  case SMT_STATUS_ERROR:
     fprintf(stderr, "Error in check_context\n");
     yices_print_error(stderr);
     break;

--- a/examples/example1c.c
+++ b/examples/example1c.c
@@ -109,7 +109,7 @@ static void simple_test(void) {
   }
 
   switch (yices_check_context(ctx, NULL)) { // call check_context, NULL means 'use default heuristics'
-  case STATUS_SAT:
+  case SMT_STATUS_SAT:
     printf("The formula is satisfiable\n");
     model_t* model = yices_get_model(ctx, true);  // get the model
     if (model == NULL) {
@@ -140,18 +140,18 @@ static void simple_test(void) {
     }
     break;
       
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     printf("The formula is not satisfiable\n");
     break;
 
-  case STATUS_UNKNOWN:
+  case SMT_STATUS_UNKNOWN:
     printf("The status is unknown\n");
     break;
 
-  case STATUS_IDLE:
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
-  case STATUS_ERROR:
+  case SMT_STATUS_IDLE:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
+  case SMT_STATUS_ERROR:
     fprintf(stderr, "Error in check_context\n");
     yices_print_error_fd(2);
     break;

--- a/examples/example2.c
+++ b/examples/example2.c
@@ -79,7 +79,7 @@ int main(void) {
   }
 
   switch (yices_check_context(ctx, NULL)) { // NULL means default heuristics
-  case STATUS_SAT:
+  case SMT_STATUS_SAT:
     // build the model and print it
     printf("Satisfiable\n");
     mdl = yices_get_model(ctx, true);
@@ -94,18 +94,18 @@ int main(void) {
     yices_free_model(mdl);
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     printf("Unsatisfiable\n");
     break;
 
-  case STATUS_UNKNOWN:
+  case SMT_STATUS_UNKNOWN:
     printf("Status is unknown\n");
     break;
 
-  case STATUS_IDLE:
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
-  case STATUS_ERROR:
+  case SMT_STATUS_IDLE:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
+  case SMT_STATUS_ERROR:
     // these codes should not be returned
     printf("Bug: unexpected status returned\n");
     break;

--- a/examples/example2b.c
+++ b/examples/example2b.c
@@ -99,7 +99,7 @@ int main(void) {
   }
 
   switch (yices_check_context(ctx, NULL)) { // NULL means default heuristics
-  case STATUS_SAT:
+  case SMT_STATUS_SAT:
     // build the model and print it
     printf("Satisfiable\n");
     mdl = yices_get_model(ctx, true);
@@ -114,18 +114,18 @@ int main(void) {
     yices_free_model(mdl);
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     printf("Unsatisfiable\n");
     break;
 
-  case STATUS_UNKNOWN:
+  case SMT_STATUS_UNKNOWN:
     printf("Status is unknown\n");
     break;
 
-  case STATUS_IDLE:
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
-  case STATUS_ERROR:
+  case SMT_STATUS_IDLE:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
+  case SMT_STATUS_ERROR:
     // these codes should not be returned
     printf("Bug: unexpected status returned\n");
     break;

--- a/examples/example2c.c
+++ b/examples/example2c.c
@@ -99,7 +99,7 @@ int main(void) {
   }
 
   switch (yices_check_context(ctx, NULL)) { // NULL means default heuristics
-  case STATUS_SAT:
+  case SMT_STATUS_SAT:
     // build the model and print it
     printf("Satisfiable\n");
     mdl = yices_get_model(ctx, true);
@@ -114,18 +114,18 @@ int main(void) {
     yices_free_model(mdl);
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     printf("Unsatisfiable\n");
     break;
 
-  case STATUS_UNKNOWN:
+  case SMT_STATUS_UNKNOWN:
     printf("Status is unknown\n");
     break;
 
-  case STATUS_IDLE:
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
-  case STATUS_ERROR:
+  case SMT_STATUS_IDLE:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
+  case SMT_STATUS_ERROR:
     // these codes should not be returned
     printf("Bug: unexpected status returned\n");
     break;

--- a/examples/example2d.c
+++ b/examples/example2d.c
@@ -92,7 +92,7 @@ int main(void) {
   }
   
   switch (yices_check_context(ctx, p)) {
-  case STATUS_SAT:
+  case SMT_STATUS_SAT:
     // build the model and print it
     printf("Satisfiable\n");
     mdl = yices_get_model(ctx, true);
@@ -107,18 +107,18 @@ int main(void) {
     yices_free_model(mdl);
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     printf("Unsatisfiable\n");
     break;
 
-  case STATUS_UNKNOWN:
+  case SMT_STATUS_UNKNOWN:
     printf("Status is unknown\n");
     break;
 
-  case STATUS_IDLE:
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
-  case STATUS_ERROR:
+  case SMT_STATUS_IDLE:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
+  case SMT_STATUS_ERROR:
     // these codes should not be returned
     printf("Bug: unexpected status returned\n");
     break;

--- a/examples/example2e.c
+++ b/examples/example2e.c
@@ -92,7 +92,7 @@ int main(void) {
   }
   
   switch (yices_check_context(ctx, p)) {
-  case STATUS_SAT:
+  case SMT_STATUS_SAT:
     // build the model and print it
     printf("Satisfiable\n");
     mdl = yices_get_model(ctx, true);
@@ -107,18 +107,18 @@ int main(void) {
     yices_free_model(mdl);
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     printf("Unsatisfiable\n");
     break;
 
-  case STATUS_UNKNOWN:
+  case SMT_STATUS_UNKNOWN:
     printf("Status is unknown\n");
     break;
 
-  case STATUS_IDLE:
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
-  case STATUS_ERROR:
+  case SMT_STATUS_IDLE:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
+  case SMT_STATUS_ERROR:
     // these codes should not be returned
     printf("Bug: unexpected status returned\n");
     break;

--- a/examples/example_mcsat.c
+++ b/examples/example_mcsat.c
@@ -130,8 +130,8 @@ static void test_mcsat(void) {
   if (code < 0) print_error();
 
   status = yices_check_context(ctx, NULL);
-  if (status != STATUS_SAT) {
-    fprintf(stderr, "Test failed: status != STATUS_SAT\n");
+  if (status != SMT_STATUS_SAT) {
+    fprintf(stderr, "Test failed: status != SMT_STATUS_SAT\n");
     exit(1);
   }
 

--- a/examples/example_unsat_core.c
+++ b/examples/example_unsat_core.c
@@ -70,7 +70,7 @@ static void check_and_get_core(context_t *ctx, uint32_t n, const term_t *a) {
 
   // NULL here means default search parameters
   switch (yices_check_context_with_assumptions(ctx, NULL, n, a)) {
-  case STATUS_SAT:
+  case SMT_STATUS_SAT:
     printf("satisfiable\n");
     model = yices_get_model(ctx, true);
     if (model == NULL) {
@@ -84,11 +84,11 @@ static void check_and_get_core(context_t *ctx, uint32_t n, const term_t *a) {
     printf("\n");
     break;
 
-  case STATUS_UNKNOWN:
+  case SMT_STATUS_UNKNOWN:
     printf("the check is inconclusive\n");
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     printf("not satisfiable\n");
 
     // initialize a vector to store the core
@@ -109,7 +109,7 @@ static void check_and_get_core(context_t *ctx, uint32_t n, const term_t *a) {
     yices_delete_term_vector(&core);
     break;
 
-  case STATUS_INTERRUPTED:
+  case SMT_STATUS_INTERRUPTED:
     printf("the check was interrupted\n");
     break;
 

--- a/examples/export_to_dimacs_example.c
+++ b/examples/export_to_dimacs_example.c
@@ -33,8 +33,8 @@ static void show_formulas(uint32_t n) {
 
 static char *status_to_string(smt_status_t status) {
   switch (status) {
-  case STATUS_SAT: return "sat";
-  case STATUS_UNSAT: return "unsat";
+  case SMT_STATUS_SAT: return "sat";
+  case SMT_STATUS_UNSAT: return "unsat";
   default: return "bug";
   }
 }

--- a/examples/export_to_dimacs_example_mt.c
+++ b/examples/export_to_dimacs_example_mt.c
@@ -39,8 +39,8 @@ static void show_formulas(term_t* formula, uint32_t n) {
 
 static char *status_to_string(smt_status_t status) {
   switch (status) {
-  case STATUS_SAT: return "sat";
-  case STATUS_UNSAT: return "unsat";
+  case SMT_STATUS_SAT: return "sat";
+  case SMT_STATUS_UNSAT: return "unsat";
   default: return "bug";
   }
 }

--- a/examples/like_issue233.c
+++ b/examples/like_issue233.c
@@ -57,7 +57,7 @@ static smt_status_t simple_check(context_t *ctx) {
   result = yices_check_context(ctx, NULL);
 
   switch (result) {
-  case STATUS_SAT:
+  case SMT_STATUS_SAT:
     printf("SATISFIABLE\n");
     full_model = yices_get_model(ctx, true);
     if (full_model != NULL) {
@@ -71,7 +71,7 @@ static smt_status_t simple_check(context_t *ctx) {
     }
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     printf("UNSATISFIABLE\n");
     interpolant = yices_get_model_interpolant(ctx);
     if (interpolant != NULL_TERM) {
@@ -84,7 +84,7 @@ static smt_status_t simple_check(context_t *ctx) {
     }
     break;
 
-  case STATUS_ERROR:
+  case SMT_STATUS_ERROR:
     fprintf(stderr, "Check failed\n");
     yices_print_error(stderr);
     exit(1);
@@ -122,7 +122,7 @@ static smt_status_t check_with_model(context_t *ctx, model_t *model, uint32_t n,
   result = yices_check_context_with_model(ctx, NULL, model, n, t);
   
   switch (result) {
-  case STATUS_SAT:
+  case SMT_STATUS_SAT:
     printf("SATISFIABLE\n");
     full_model = yices_get_model(ctx, true);
     if (full_model != NULL) {
@@ -136,7 +136,7 @@ static smt_status_t check_with_model(context_t *ctx, model_t *model, uint32_t n,
     }
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     printf("UNSATISFIABLE\n");
     interpolant = yices_get_model_interpolant(ctx);
     if (interpolant != NULL_TERM) {
@@ -149,7 +149,7 @@ static smt_status_t check_with_model(context_t *ctx, model_t *model, uint32_t n,
     }
     break;
     
-  case STATUS_ERROR:
+  case SMT_STATUS_ERROR:
     fprintf(stderr, "Check with model failed\n");
     yices_print_error(stderr);
     exit(1);
@@ -193,7 +193,7 @@ static void run_issue233(void) {
   }
 
   stat = simple_check(ctx);
-  if (stat != STATUS_SAT) {
+  if (stat != SMT_STATUS_SAT) {
     fprintf(stderr, "Incorrect answer from check-sat: expected SAT\n");
     exit(1);
   }
@@ -207,13 +207,13 @@ static void run_issue233(void) {
   }
 
   stat = check_with_model(ctx, model, 1, &x);
-  if (stat != STATUS_UNSAT) {
+  if (stat != SMT_STATUS_UNSAT) {
     fprintf(stderr, "Incorrect answer from check-with-model: expected UNSAT\n");
     exit(1);
   }
 
   stat = simple_check(ctx);
-  if (stat != STATUS_SAT) {
+  if (stat != SMT_STATUS_SAT) {
     fprintf(stderr, "Incorrect answer from check-sat: expected SAT\n");
     exit(1);
   }

--- a/examples/like_test02m.c
+++ b/examples/like_test02m.c
@@ -91,7 +91,7 @@ static smt_status_t simple_check(context_t *ctx) {
   result = yices_check_context(ctx, NULL);
 
   switch (result) {
-  case STATUS_SAT:
+  case SMT_STATUS_SAT:
     printf("SATISFIABLE\n");
     full_model = yices_get_model(ctx, true);
     if (full_model != NULL) {
@@ -105,7 +105,7 @@ static smt_status_t simple_check(context_t *ctx) {
     }
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     printf("UNSATISFIABLE\n");
     interpolant = yices_get_model_interpolant(ctx);
     if (interpolant != NULL_TERM) {
@@ -118,7 +118,7 @@ static smt_status_t simple_check(context_t *ctx) {
     }
     break;
 
-  case STATUS_ERROR:
+  case SMT_STATUS_ERROR:
     fprintf(stderr, "Check failed\n");
     yices_print_error(stderr);
     break;
@@ -156,7 +156,7 @@ static smt_status_t check_with_model(context_t *ctx, model_t *model, uint32_t n,
   result = yices_check_context_with_model(ctx, NULL, model, n, t);
   
   switch (result) {
-  case STATUS_SAT:
+  case SMT_STATUS_SAT:
     printf("SATISFIABLE\n");
     full_model = yices_get_model(ctx, true);
     if (full_model != NULL) {
@@ -170,7 +170,7 @@ static smt_status_t check_with_model(context_t *ctx, model_t *model, uint32_t n,
     }
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     printf("UNSATISFIABLE\n");
     interpolant = yices_get_model_interpolant(ctx);
     if (interpolant != NULL_TERM) {
@@ -183,7 +183,7 @@ static smt_status_t check_with_model(context_t *ctx, model_t *model, uint32_t n,
     }
     break;
     
-  case STATUS_ERROR:
+  case SMT_STATUS_ERROR:
     fprintf(stderr, "Check with model failed\n");
     yices_print_error(stderr);
     break;
@@ -325,7 +325,7 @@ static void run_test02m(void) {
 
   // check-with-model
   stat = check_with_model(ctx, model, 3, var);
-  if (stat != STATUS_UNSAT) {
+  if (stat != SMT_STATUS_UNSAT) {
     fprintf(stderr, "Incorrect answer from check-with-model: expected UNSAT\n");
     exit(1);
   }
@@ -341,14 +341,14 @@ static void run_test02m(void) {
 
   // check with model: unsat + interpolant
   stat = check_with_model(ctx, model, 3, var);
-  if (stat != STATUS_UNSAT) {
+  if (stat != SMT_STATUS_UNSAT) {
     fprintf(stderr, "Incorrect answer from check-with-model: expected UNSAT\n");
     exit(1);
   }
 
   // check-sat: sat
   stat = simple_check(ctx);
-  if (stat != STATUS_SAT) {
+  if (stat != SMT_STATUS_SAT) {
     fprintf(stderr, "Incorrect answer from check-sat: expected SAT\n");
     exit(1);
   }
@@ -358,7 +358,7 @@ static void run_test02m(void) {
 
   // check with model: unsat + interpolant
   stat = check_with_model(ctx, model, 3, var);
-  if (stat != STATUS_UNSAT) {
+  if (stat != SMT_STATUS_UNSAT) {
     fprintf(stderr, "Incorrect answer from check-with-model: expected UNSAT\n");
     exit(1);
   }
@@ -374,7 +374,7 @@ static void run_test02m(void) {
 
   // check with model: unsat + interpolant
   stat = check_with_model(ctx, model, 3, var);
-  if (stat != STATUS_UNSAT) {
+  if (stat != SMT_STATUS_UNSAT) {
     fprintf(stderr, "Incorrect answer from check-with-model: expected UNSAT\n");
     exit(1);
   }
@@ -393,14 +393,14 @@ static void run_test02m(void) {
 
   // simple check: expect UNSAT + interpolant
   stat = simple_check(ctx);
-  if (stat != STATUS_UNSAT) {
+  if (stat != SMT_STATUS_UNSAT) {
     fprintf(stderr, "Incorrect answer from check: expected UNSAT\n");
     exit(1);
   }
 
   // check with model: unsat + interpolant (should be false)
   stat = check_with_model(ctx, model, 3, var);
-  if (stat != STATUS_UNSAT) {
+  if (stat != SMT_STATUS_UNSAT) {
     fprintf(stderr, "Incorrect answer from check-with-model: expected UNSAT\n");
     exit(1);
   }

--- a/examples/test_check_with_model.c
+++ b/examples/test_check_with_model.c
@@ -96,7 +96,7 @@ static void check_with_model(context_t *ctx, model_t *model, term_t assertion, u
   }
 
   switch (yices_check_context_with_model(ctx, NULL, model, n, t)) {
-  case STATUS_SAT:
+  case SMT_STATUS_SAT:
     printf("SATISFIABLE\n");
     full_model = yices_get_model(ctx, true);
     if (full_model != NULL) {
@@ -110,7 +110,7 @@ static void check_with_model(context_t *ctx, model_t *model, term_t assertion, u
     }
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     printf("UNSATISFIABLE\n");
     interpolant = yices_get_model_interpolant(ctx);
     if (interpolant != NULL_TERM) {
@@ -123,7 +123,7 @@ static void check_with_model(context_t *ctx, model_t *model, term_t assertion, u
     }
     break;
     
-  case STATUS_ERROR:
+  case SMT_STATUS_ERROR:
     fprintf(stderr, "Check with model failed\n");
     yices_print_error(stderr);
     exit(1);
@@ -160,7 +160,7 @@ static void check(context_t *ctx, term_t assertion) {
   }
 
   switch (yices_check_context(ctx, NULL)) {
-  case STATUS_SAT:
+  case SMT_STATUS_SAT:
     printf("SATISFIABLE\n");
     full_model = yices_get_model(ctx, true);
     if (full_model != NULL) {
@@ -174,7 +174,7 @@ static void check(context_t *ctx, term_t assertion) {
     }
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     printf("UNSATISFIABLE\n");
     interpolant = yices_get_model_interpolant(ctx);
     if (interpolant != NULL_TERM) {
@@ -187,7 +187,7 @@ static void check(context_t *ctx, term_t assertion) {
     }
     break;
     
-  case STATUS_ERROR:
+  case SMT_STATUS_ERROR:
     fprintf(stderr, "Check failed\n");
     yices_print_error(stderr);
     exit(1);

--- a/src/api/yices_api.c
+++ b/src/api/yices_api.c
@@ -8494,34 +8494,34 @@ EXPORTED int32_t yices_push(context_t *ctx) {
   }
 
   switch (context_status(ctx)) {
-  case STATUS_UNKNOWN:
-  case STATUS_SAT:
+  case SMT_STATUS_UNKNOWN:
+  case SMT_STATUS_SAT:
     context_clear(ctx);
     break;
 
-  case STATUS_IDLE:
+  case SMT_STATUS_IDLE:
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     // try to remove assumptions
     context_clear_unsat(ctx);
-    if (context_status(ctx) == STATUS_IDLE) {
+    if (context_status(ctx) == SMT_STATUS_IDLE) {
       break;
     }
-    assert(context_status(ctx) == STATUS_UNSAT);
+    assert(context_status(ctx) == SMT_STATUS_UNSAT);
     // fall through
-  case STATUS_INTERRUPTED:
-  case STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
+  case SMT_STATUS_SEARCHING:
     set_error_code(CTX_INVALID_OPERATION);
     return -1;
 
-  case STATUS_ERROR:
+  case SMT_STATUS_ERROR:
   default:
     set_error_code(INTERNAL_EXCEPTION);
     return -1;
   }
 
-  assert(context_status(ctx) == STATUS_IDLE);
+  assert(context_status(ctx) == SMT_STATUS_IDLE);
   context_push(ctx);
 
   return 0;
@@ -8553,31 +8553,31 @@ EXPORTED int32_t yices_pop(context_t *ctx) {
   }
 
   switch (context_status(ctx)) {
-  case STATUS_UNKNOWN:
-  case STATUS_SAT:
-  case STATUS_INTERRUPTED:
+  case SMT_STATUS_UNKNOWN:
+  case SMT_STATUS_SAT:
+  case SMT_STATUS_INTERRUPTED:
     context_clear(ctx);
     break;
 
-  case STATUS_IDLE:
+  case SMT_STATUS_IDLE:
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     context_clear_unsat(ctx);
     break;
 
-  case STATUS_SEARCHING:
+  case SMT_STATUS_SEARCHING:
     set_error_code(CTX_INVALID_OPERATION);
     return -1;
 
-  case STATUS_ERROR:
+  case SMT_STATUS_ERROR:
   default:
     set_error_code(INTERNAL_EXCEPTION);
     return -1;
   }
 
-  assert(context_status(ctx) == STATUS_IDLE ||
-	 context_status(ctx) == STATUS_UNSAT);
+  assert(context_status(ctx) == SMT_STATUS_IDLE ||
+	 context_status(ctx) == SMT_STATUS_UNSAT);
   context_pop(ctx);
 
   return 0;
@@ -8677,8 +8677,8 @@ int32_t _o_yices_assert_formula(context_t *ctx, term_t t) {
   }
 
   switch (context_status(ctx)) {
-  case STATUS_UNKNOWN:
-  case STATUS_SAT:
+  case SMT_STATUS_UNKNOWN:
+  case SMT_STATUS_SAT:
     if (! context_supports_multichecks(ctx)) {
       set_error_code(CTX_OPERATION_NOT_SUPPORTED);
       return -1;
@@ -8686,30 +8686,30 @@ int32_t _o_yices_assert_formula(context_t *ctx, term_t t) {
     context_clear(ctx);
     break;
 
-  case STATUS_IDLE:
+  case SMT_STATUS_IDLE:
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     // try to remove assumptions
     context_clear_unsat(ctx);
-    if (context_status(ctx) == STATUS_UNSAT) {
+    if (context_status(ctx) == SMT_STATUS_UNSAT) {
       // nothing to do
       return 0;
     }
     break;
 
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
     set_error_code(CTX_INVALID_OPERATION);
     return -1;
 
-  case STATUS_ERROR:
+  case SMT_STATUS_ERROR:
   default:
     set_error_code(INTERNAL_EXCEPTION);
     return -1;
   }
 
-  assert(context_status(ctx) == STATUS_IDLE);
+  assert(context_status(ctx) == SMT_STATUS_IDLE);
 
   code = _o_assert_formula(ctx, t);
   if (code < 0) {
@@ -8751,8 +8751,8 @@ EXPORTED int32_t yices_assert_formulas(context_t *ctx, uint32_t n, const term_t 
   }
 
   switch (context_status(ctx)) {
-  case STATUS_UNKNOWN:
-  case STATUS_SAT:
+  case SMT_STATUS_UNKNOWN:
+  case SMT_STATUS_SAT:
     if (! context_supports_multichecks(ctx)) {
       set_error_code(CTX_OPERATION_NOT_SUPPORTED);
       return -1;
@@ -8760,30 +8760,30 @@ EXPORTED int32_t yices_assert_formulas(context_t *ctx, uint32_t n, const term_t 
     context_clear(ctx);
     break;
 
-  case STATUS_IDLE:
+  case SMT_STATUS_IDLE:
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     // try to remove assumptions
     context_clear_unsat(ctx);
-    if (context_status(ctx) == STATUS_UNSAT) {
+    if (context_status(ctx) == SMT_STATUS_UNSAT) {
       // nothing to do
       return 0;
     }
     break;
 
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
     set_error_code(CTX_INVALID_OPERATION);
     return -1;
 
-  case STATUS_ERROR:
+  case SMT_STATUS_ERROR:
   default:
     set_error_code(INTERNAL_EXCEPTION);
     return -1;
   }
 
-  assert(context_status(ctx) == STATUS_IDLE);
+  assert(context_status(ctx) == SMT_STATUS_IDLE);
 
   code = assert_formulas(ctx, n, t);
   if (code < 0) {
@@ -8815,8 +8815,8 @@ EXPORTED int32_t yices_assert_formulas(context_t *ctx, uint32_t n, const term_t 
  */
 EXPORTED int32_t yices_assert_blocking_clause(context_t *ctx) {
   switch (context_status(ctx)) {
-  case STATUS_UNKNOWN:
-  case STATUS_SAT:
+  case SMT_STATUS_UNKNOWN:
+  case SMT_STATUS_SAT:
     if (context_supports_multichecks(ctx)) {
       assert_blocking_clause(ctx);
       return 0;
@@ -8825,14 +8825,14 @@ EXPORTED int32_t yices_assert_blocking_clause(context_t *ctx) {
       return -1;
     }
 
-  case STATUS_UNSAT:
-  case STATUS_IDLE:
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
+  case SMT_STATUS_UNSAT:
+  case SMT_STATUS_IDLE:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
     set_error_code(CTX_INVALID_OPERATION);
     return -1;
 
-  case STATUS_ERROR:
+  case SMT_STATUS_ERROR:
   default:
     set_error_code(INTERNAL_EXCEPTION);
     return -1;
@@ -9000,7 +9000,7 @@ EXPORTED void yices_default_params_for_context(const context_t *ctx, param_t *pa
  *
  *    The returned status is also stored as the new ctx's status flag.
  *
- * 3) Otherwise, the function does nothing and returns 'STATUS_ERROR',
+ * 3) Otherwise, the function does nothing and returns 'SMT_STATUS_ERROR',
  *    it also sets the yices error report (code = CTX_INVALID_OPERATION).
  */
 EXPORTED smt_status_t yices_check_context(context_t *ctx, const param_t *params) {
@@ -9009,41 +9009,41 @@ EXPORTED smt_status_t yices_check_context(context_t *ctx, const param_t *params)
 
   stat = context_status(ctx);
   switch (stat) {
-  case STATUS_UNKNOWN:
-  case STATUS_SAT:
+  case SMT_STATUS_UNKNOWN:
+  case SMT_STATUS_SAT:
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     // remove assumptions if any
     context_clear_unsat(ctx);
-    if (context_status(ctx) == STATUS_UNSAT) {
+    if (context_status(ctx) == SMT_STATUS_UNSAT) {
       // no assumptions removed: still unsat
       break;
     }
-    assert(context_status(ctx) == STATUS_IDLE);
+    assert(context_status(ctx) == SMT_STATUS_IDLE);
 
     // fall through intended
-  case STATUS_IDLE:
+  case SMT_STATUS_IDLE:
     if (params == NULL) {
       yices_default_params_for_context(ctx, &default_params);
       params = &default_params;
     }
     stat = check_context(ctx, params);
-    if (stat == STATUS_INTERRUPTED && context_supports_cleaninterrupt(ctx)) {
+    if (stat == SMT_STATUS_INTERRUPTED && context_supports_cleaninterrupt(ctx)) {
       context_cleanup(ctx);
     }
     break;
 
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
     set_error_code(CTX_INVALID_OPERATION);
-    stat = STATUS_ERROR;
+    stat = SMT_STATUS_ERROR;
     break;
 
-  case STATUS_ERROR:
+  case SMT_STATUS_ERROR:
   default:
     set_error_code(INTERNAL_EXCEPTION);
-    stat = STATUS_ERROR;
+    stat = SMT_STATUS_ERROR;
     break;
   }
 
@@ -9071,47 +9071,47 @@ smt_status_t _o_yices_check_context_with_assumptions(context_t *ctx, const param
   literal_t l;
 
   if (!_o_unsat_core_check_assumptions(n, a)) {
-    return STATUS_ERROR; // Bad assumptions
+    return SMT_STATUS_ERROR; // Bad assumptions
   }
 
   // cleanup
   switch (context_status(ctx)) {
-  case STATUS_UNKNOWN:
-  case STATUS_SAT:
+  case SMT_STATUS_UNKNOWN:
+  case SMT_STATUS_SAT:
     if (! context_supports_multichecks(ctx)) {
       set_error_code(CTX_OPERATION_NOT_SUPPORTED);
-      return STATUS_ERROR;
+      return SMT_STATUS_ERROR;
     }
     context_clear(ctx);
     break;
 
-  case STATUS_IDLE:
+  case SMT_STATUS_IDLE:
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     if (! context_supports_multichecks(ctx)) {
       set_error_code(CTX_OPERATION_NOT_SUPPORTED);
-      return STATUS_ERROR;
+      return SMT_STATUS_ERROR;
     }
     // try to remove the previous assumptions if any
     context_clear_unsat(ctx);
-    if (context_status(ctx) == STATUS_UNSAT) {
-      return STATUS_UNSAT;
+    if (context_status(ctx) == SMT_STATUS_UNSAT) {
+      return SMT_STATUS_UNSAT;
     }
     break;
 
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
     set_error_code(CTX_INVALID_OPERATION);
-    return STATUS_ERROR;
+    return SMT_STATUS_ERROR;
 
-  case STATUS_ERROR:
+  case SMT_STATUS_ERROR:
   default:
     set_error_code(INTERNAL_EXCEPTION);
-    return STATUS_ERROR;
+    return SMT_STATUS_ERROR;
   }
 
-  assert(context_status(ctx) == STATUS_IDLE);
+  assert(context_status(ctx) == SMT_STATUS_IDLE);
 
   // convert the assumptions to n literals
   init_ivector(&assumptions, n);
@@ -9120,7 +9120,7 @@ smt_status_t _o_yices_check_context_with_assumptions(context_t *ctx, const param
     if (l < 0) {
       // error when converting a[i] to a literal
       convert_internalization_error(l);
-      stat = STATUS_ERROR;
+      stat = SMT_STATUS_ERROR;
       yices_release_mutex();
       goto cleanup;
     }
@@ -9136,7 +9136,7 @@ smt_status_t _o_yices_check_context_with_assumptions(context_t *ctx, const param
 
   // call check
   stat = check_context_with_assumptions(ctx, params, n, assumptions.data);
-  if (stat == STATUS_INTERRUPTED && context_supports_cleaninterrupt(ctx)) {
+  if (stat == SMT_STATUS_INTERRUPTED && context_supports_cleaninterrupt(ctx)) {
     context_cleanup(ctx);
   }
 
@@ -9180,49 +9180,49 @@ EXPORTED smt_status_t yices_check_context_with_model(context_t *ctx, const param
 
   if (! context_has_mcsat(ctx)) {
     set_error_code(CTX_OPERATION_NOT_SUPPORTED);
-    return STATUS_ERROR;
+    return SMT_STATUS_ERROR;
   }
 
   if (! good_terms_for_check_with_model(n, t)) {
     // this sets the error code already (to VARIABLE_REQUIRED)
     // but Dejan created another error code that means the same thing here.
     set_error_code(MCSAT_ERROR_ASSUMPTION_TERM_NOT_SUPPORTED);
-    return STATUS_ERROR;
+    return SMT_STATUS_ERROR;
   }
 
   // cleanup
   switch (context_status(ctx)) {
-  case STATUS_UNKNOWN:
-  case STATUS_SAT:
+  case SMT_STATUS_UNKNOWN:
+  case SMT_STATUS_SAT:
     if (! context_supports_multichecks(ctx)) {
       set_error_code(CTX_OPERATION_NOT_SUPPORTED);
-      return STATUS_ERROR;
+      return SMT_STATUS_ERROR;
     }
     context_clear(ctx);
     break;
 
-  case STATUS_IDLE:
+  case SMT_STATUS_IDLE:
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     context_clear_unsat(ctx);
-    if (context_status(ctx) == STATUS_UNSAT) {
-      return STATUS_UNSAT;
+    if (context_status(ctx) == SMT_STATUS_UNSAT) {
+      return SMT_STATUS_UNSAT;
     }
     break;
 
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
     set_error_code(CTX_INVALID_OPERATION);
-    return STATUS_ERROR;
+    return SMT_STATUS_ERROR;
 
-  case STATUS_ERROR:
+  case SMT_STATUS_ERROR:
   default:
     set_error_code(INTERNAL_EXCEPTION);
-    return STATUS_ERROR;
+    return SMT_STATUS_ERROR;
   }
 
-  assert(context_status(ctx) == STATUS_IDLE);
+  assert(context_status(ctx) == SMT_STATUS_IDLE);
 
   // set parameters
   if (params == NULL) {
@@ -9232,7 +9232,7 @@ EXPORTED smt_status_t yices_check_context_with_model(context_t *ctx, const param
 
   // call check
   stat = check_context_with_model(ctx, params, mdl, n, t);
-  if (stat == STATUS_INTERRUPTED && context_supports_cleaninterrupt(ctx)) {
+  if (stat == SMT_STATUS_INTERRUPTED && context_supports_cleaninterrupt(ctx)) {
     context_cleanup(ctx);
   }
 
@@ -9247,24 +9247,24 @@ EXPORTED smt_status_t yices_check_context_with_model(context_t *ctx, const param
 EXPORTED smt_status_t yices_check_context_with_interpolation(interpolation_context_t *ctx, const param_t *params, int32_t build_model) {
   int32_t ret = 0;
   model_t *model = NULL;
-  smt_status_t result = STATUS_UNKNOWN;
+  smt_status_t result = SMT_STATUS_UNKNOWN;
   ivector_t model_vars, interpolants;
 
   // The context must stupport interpolation
   if (! context_supports_model_interpolation(ctx->ctx_A)) {
     set_error_code(CTX_OPERATION_NOT_SUPPORTED);
-    return STATUS_ERROR;
+    return SMT_STATUS_ERROR;
   }
 
   // Push A and B so we can revert
   ret = yices_push(ctx->ctx_A);
   if (ret) {
-    return STATUS_ERROR;
+    return SMT_STATUS_ERROR;
   }
   ret = yices_push(ctx->ctx_B);
   if (ret) {
     yices_pop(ctx->ctx_A);
-    return STATUS_ERROR;
+    return SMT_STATUS_ERROR;
   }
 
   // Search: find models of B and refute with B
@@ -9277,14 +9277,14 @@ EXPORTED smt_status_t yices_check_context_with_interpolation(interpolation_conte
     result = yices_check_context(ctx->ctx_B, params);
 
     // UNSAT, interrupts and errors, we're done
-    if (result != STATUS_SAT) {
+    if (result != SMT_STATUS_SAT) {
       break;
     }
 
     // B is satisfiable, refute
     model = yices_get_model(ctx->ctx_B, 1);
     if (model == NULL) {
-      result = STATUS_ERROR;
+      result = SMT_STATUS_ERROR;
       break;
     }
 
@@ -9299,14 +9299,14 @@ EXPORTED smt_status_t yices_check_context_with_interpolation(interpolation_conte
     result = yices_check_context_with_model(ctx->ctx_A, params, model, model_vars.size, model_vars.data);
 
     // SAT, interrupts and errors, we're done
-    if (result != STATUS_UNSAT) {
+    if (result != SMT_STATUS_UNSAT) {
       break;
     }
 
     // UNSAT, get the interpolant
     term_t model_interpolant = yices_get_model_interpolant(ctx->ctx_A);
     if (model_interpolant == NULL_TERM) {
-      result = STATUS_ERROR;
+      result = SMT_STATUS_ERROR;
       break;
     }
     ivector_push(&interpolants, model_interpolant);
@@ -9326,7 +9326,7 @@ EXPORTED smt_status_t yices_check_context_with_interpolation(interpolation_conte
 //    yices_push(ctx->ctx_A);
 //    yices_assert_formula(ctx->ctx_A, opposite_term(model_interpolant));
 //    smt_status_t interpolant_status = yices_check_context(ctx->ctx_A, NULL);
-//    assert(interpolant_status == STATUS_UNSAT);
+//    assert(interpolant_status == SMT_STATUS_UNSAT);
 //    yices_pop(ctx->ctx_A);
 
     // Add the inteprolant to B
@@ -9337,23 +9337,23 @@ EXPORTED smt_status_t yices_check_context_with_interpolation(interpolation_conte
     model = NULL;
   }
 
-  if (result == STATUS_UNSAT) {
+  if (result == SMT_STATUS_UNSAT) {
     // Construct the interpolant if UNSAT
     ctx->interpolant = yices_and(interpolants.size, interpolants.data);
-  } else if (result == STATUS_SAT && build_model) {
+  } else if (result == SMT_STATUS_SAT && build_model) {
     // Construct the model if SAT and asked
     ctx->model = yices_get_model(ctx->ctx_A, true);
   }
 
   // Pop both contexts
-  if (result != STATUS_ERROR) {
+  if (result != SMT_STATUS_ERROR) {
     ret = yices_pop(ctx->ctx_B);
     if (ret) {
-      result = STATUS_ERROR;
+      result = SMT_STATUS_ERROR;
     } else {
       ret = yices_pop(ctx->ctx_A);
       if (ret) {
-        result = STATUS_ERROR;
+        result = SMT_STATUS_ERROR;
       }
     }
   }
@@ -9380,7 +9380,7 @@ EXPORTED smt_status_t yices_check_context_with_interpolation(interpolation_conte
  * INTERRUPTED. Otherwise, the function does nothing.
  */
 EXPORTED void yices_stop_search(context_t *ctx) {
-  if (context_status(ctx) == STATUS_SEARCHING) {
+  if (context_status(ctx) == SMT_STATUS_SEARCHING) {
     context_stop_search(ctx);
   }
 }
@@ -9397,7 +9397,7 @@ EXPORTED void yices_stop_search(context_t *ctx) {
  * - returns -1 if there's an error
  */
 EXPORTED int32_t yices_get_unsat_core(context_t *ctx, term_vector_t *v) {
-  if (context_status(ctx) != STATUS_UNSAT) {
+  if (context_status(ctx) != SMT_STATUS_UNSAT) {
     set_error_code(CTX_INVALID_OPERATION);
     return -1;
   }
@@ -9430,7 +9430,7 @@ EXPORTED term_t yices_get_model_interpolant(context_t *ctx) {
   result = NULL_TERM;
   if (! context_supports_model_interpolation(ctx)) {
     set_error_code(CTX_OPERATION_NOT_SUPPORTED);
-  } else if (context_status(ctx) != STATUS_UNSAT) {
+  } else if (context_status(ctx) != SMT_STATUS_UNSAT) {
     set_error_code(CTX_INVALID_OPERATION);
   } else {
     result = context_get_unsat_model_interpolant(ctx);
@@ -9469,8 +9469,8 @@ model_t *_o_yices_get_model(context_t *ctx, int32_t keep_subst) {
   assert(ctx != NULL);
 
   switch (context_status(ctx)) {
-  case STATUS_UNKNOWN:
-  case STATUS_SAT:
+  case SMT_STATUS_UNKNOWN:
+  case SMT_STATUS_SAT:
     mdl = alloc_model();
     init_model(mdl, __yices_globals.terms, (keep_subst != 0));
     context_build_model(mdl, ctx);
@@ -10290,7 +10290,7 @@ static smt_status_t yices_ef_check_formulas(const term_t f[], uint32_t n, smt_lo
   if (efc.efcode != EF_NO_ERROR) {
     // error in preprocessing. no efsolver created
     set_error_code(efcode2yices_error[efc.efcode]);
-    stat = STATUS_ERROR;
+    stat = SMT_STATUS_ERROR;
 
   } else {
 
@@ -10304,19 +10304,19 @@ static smt_status_t yices_ef_check_formulas(const term_t f[], uint32_t n, smt_lo
       model = ef_export_model(&efc, &ef_code);
       assert(ef_code == EFMODEL_CODE_NO_ERROR);
       *result = model;
-      stat = STATUS_SAT;
+      stat = SMT_STATUS_SAT;
       break;
 
     case EF_STATUS_UNSAT:
-      stat = STATUS_UNSAT;
+      stat = SMT_STATUS_UNSAT;
       break;
 
     case EF_STATUS_UNKNOWN:
-      stat = STATUS_UNKNOWN;
+      stat = SMT_STATUS_UNKNOWN;
       break;
 
     case EF_STATUS_INTERRUPTED:
-      stat = STATUS_INTERRUPTED;
+      stat = SMT_STATUS_INTERRUPTED;
       break;
 
     case EF_STATUS_SUBST_ERROR:
@@ -10326,13 +10326,13 @@ static smt_status_t yices_ef_check_formulas(const term_t f[], uint32_t n, smt_lo
 	assert(error == -2);
 	set_error_code(CTX_EF_INTERNAL_ERROR);
       }
-      stat = STATUS_ERROR;
+      stat = SMT_STATUS_ERROR;
       break;
 
     case EF_STATUS_ASSERT_ERROR:
       assert(error < 0);
       yices_internalization_error(error);
-      stat = STATUS_ERROR;
+      stat = SMT_STATUS_ERROR;
       break;
 
     case EF_STATUS_PROJECTION_ERROR:
@@ -10341,13 +10341,13 @@ static smt_status_t yices_ef_check_formulas(const term_t f[], uint32_t n, smt_lo
       } else {
 	set_error_code(CTX_EF_INTERNAL_ERROR);
       }
-      stat = STATUS_ERROR;
+      stat = SMT_STATUS_ERROR;
       break;
 
     default:
       // todo: give more precise diagnostic
       set_error_code(CTX_EF_INTERNAL_ERROR);
-      stat = STATUS_ERROR;
+      stat = SMT_STATUS_ERROR;
       break;
     }
   }
@@ -10382,7 +10382,7 @@ static smt_status_t yices_do_check_formulas(const term_t f[], uint32_t n, const 
     logic = smt_logic_code(logic_name);
     if (logic == SMT_UNKNOWN) {
       set_error_code(CTX_UNKNOWN_LOGIC);
-      return STATUS_ERROR;
+      return SMT_STATUS_ERROR;
     }
     if (logic_is_supported_by_ef(logic)) {
       return yices_ef_check_formulas(f, n, logic, result);
@@ -10391,7 +10391,7 @@ static smt_status_t yices_do_check_formulas(const term_t f[], uint32_t n, const 
     if (! logic_is_supported(logic) ||
 	(! yices_has_mcsat() && logic_requires_mcsat(logic))) {
       set_error_code(CTX_LOGIC_NOT_SUPPORTED);
-      return STATUS_ERROR;
+      return SMT_STATUS_ERROR;
     }
 
     arch = arch_for_logic(logic);
@@ -10401,16 +10401,16 @@ static smt_status_t yices_do_check_formulas(const term_t f[], uint32_t n, const 
 
   // validate the delegate if given
   if (logic == QF_BV && delegate != NULL && !check_delegate(delegate)) {
-    return STATUS_ERROR;
+    return SMT_STATUS_ERROR;
   }
 
   // check for trivial unsat then trivial sat
   if (trivially_false_assertions(f, n)) {
-    return STATUS_UNSAT;
+    return SMT_STATUS_UNSAT;
   }
 
   if (trivially_true_assertions(f, n, result)) {
-    return STATUS_SAT;
+    return SMT_STATUS_SAT;
   }
 
   // initialize the context and assert the formulas
@@ -10423,7 +10423,7 @@ static smt_status_t yices_do_check_formulas(const term_t f[], uint32_t n, const 
   if (code < 0) {
     // error in assert_formulas
     convert_internalization_error(code);
-    status = STATUS_ERROR;
+    status = SMT_STATUS_ERROR;
     goto cleanup;
   }
 
@@ -10436,7 +10436,7 @@ static smt_status_t yices_do_check_formulas(const term_t f[], uint32_t n, const 
   }
 
   // get the model
-  if (status == STATUS_SAT && result != NULL) {
+  if (status == SMT_STATUS_SAT && result != NULL) {
     // yices_get_model takes the lock so we don't
     // need to do it ourselves.
     model = yices_get_model(&context, true);
@@ -10463,9 +10463,9 @@ static smt_status_t yices_do_check_formulas(const term_t f[], uint32_t n, const 
  * assert f in this context and check whether the context is satisfiable.
  *
  * The return value is
- *   STATUS_SAT if f is satisfiable,
- *   STATUS_UNSAT if f is not satisifiable
- *   STATUS_ERROR if something goes wrong
+ *   SMT_STATUS_SAT if f is satisfiable,
+ *   SMT_STATUS_UNSAT if f is not satisifiable
+ *   SMT_STATUS_ERROR if something goes wrong
  *
  * If the formula is satisfiable and model != NULL, then a model of f is returned in *model.
  * That model must be deleted when no-longer needed by calling yices_free_model.
@@ -10481,7 +10481,7 @@ static smt_status_t yices_do_check_formulas(const term_t f[], uint32_t n, const 
  * If delegate is NULL, the default SAT solver is used.
  *
  * Support for "cadical" and "cryptominisat" must be enabled at compilation
- * time. The "y2sat" solver is always available. The function will return STATUS_ERROR
+ * time. The "y2sat" solver is always available. The function will return SMT_STATUS_ERROR
  * and store an error code if the requested delegate is not available.
  *
  * Error codes:
@@ -10512,7 +10512,7 @@ static smt_status_t yices_do_check_formulas(const term_t f[], uint32_t n, const 
  */
 EXPORTED smt_status_t yices_check_formula(term_t f, const char *logic, model_t **model, const char *delegate) {
   if (! yices_assert_formula_checks(f)) {
-    return STATUS_ERROR;
+    return SMT_STATUS_ERROR;
   }
   return yices_do_check_formulas(&f, 1, logic, model, delegate);
 }
@@ -10527,7 +10527,7 @@ EXPORTED smt_status_t yices_check_formula(term_t f, const char *logic, model_t *
  */
 EXPORTED smt_status_t yices_check_formulas(const term_t f[], uint32_t n, const char *logic, model_t **model, const char *delegate) {
   if (! yices_assert_formulas_checks(n, f)) {
-    return STATUS_ERROR;
+    return SMT_STATUS_ERROR;
   }
   return yices_do_check_formulas(f, n, logic, model, delegate);
 }
@@ -10550,12 +10550,12 @@ static int32_t yices_do_export_to_dimacs(const term_t f[], uint32_t n, const cha
   int32_t code;
 
   if (trivially_false_assertions(f, n)) {
-    *status = STATUS_UNSAT;
+    *status = SMT_STATUS_UNSAT;
     return 0;
   }
 
   if (trivially_true_assertions(f, n, NULL)) {
-    *status = STATUS_SAT;
+    *status = SMT_STATUS_SAT;
     return 0;
   }
 
@@ -10577,7 +10577,7 @@ static int32_t yices_do_export_to_dimacs(const term_t f[], uint32_t n, const cha
   }
 
   if (code == TRIVIALLY_UNSAT) {
-    *status = STATUS_UNSAT;
+    *status = SMT_STATUS_UNSAT;
     code = 0;
     goto done;
   }

--- a/src/context/context.c
+++ b/src/context/context.c
@@ -6209,7 +6209,7 @@ int32_t _o_assert_formulas(context_t *ctx, uint32_t n, const term_t *f) {
 
   assert(ctx->arch == CTX_ARCH_AUTO_IDL ||
          ctx->arch == CTX_ARCH_AUTO_RDL ||
-         smt_status(ctx->core) == STATUS_IDLE);
+         smt_status(ctx->core) == SMT_STATUS_IDLE);
   assert(!context_quant_enabled(ctx));
 
   code = context_process_assertions(ctx, n, f);
@@ -6223,10 +6223,10 @@ int32_t _o_assert_formulas(context_t *ctx, uint32_t n, const term_t *f) {
       ctx->options = 0;
     }
 
-    if( smt_status(ctx->core) != STATUS_UNSAT) {
+    if( smt_status(ctx->core) != SMT_STATUS_UNSAT) {
       // force UNSAT in the core
       add_empty_clause(ctx->core);
-      ctx->core->status = STATUS_UNSAT;
+      ctx->core->status = SMT_STATUS_UNSAT;
     }
   }
 
@@ -6248,7 +6248,7 @@ int32_t quant_assert_formulas(context_t *ctx, uint32_t n, const term_t *f) {
   int32_t code;
 
   assert(context_quant_enabled(ctx));
-  assert(smt_status(ctx->core) == STATUS_SEARCHING);
+  assert(smt_status(ctx->core) == SMT_STATUS_SEARCHING);
 
   code = context_process_assertions(ctx, n, f);
   if (code == TRIVIALLY_UNSAT) {
@@ -6261,10 +6261,10 @@ int32_t quant_assert_formulas(context_t *ctx, uint32_t n, const term_t *f) {
       ctx->options = 0;
     }
 
-    if( smt_status(ctx->core) != STATUS_UNSAT) {
+    if( smt_status(ctx->core) != SMT_STATUS_UNSAT) {
       // force UNSAT in the core
       add_empty_clause(ctx->core);
-      ctx->core->status = STATUS_UNSAT;
+      ctx->core->status = SMT_STATUS_UNSAT;
     }
   }
 
@@ -6607,8 +6607,8 @@ int32_t assert_blocking_clause(context_t *ctx) {
   uint32_t i, n;
   int32_t code;
 
-  assert(smt_status(ctx->core) == STATUS_SAT ||
-         smt_status(ctx->core) == STATUS_UNKNOWN);
+  assert(smt_status(ctx->core) == SMT_STATUS_SAT ||
+         smt_status(ctx->core) == SMT_STATUS_UNKNOWN);
 
   // get decision literals and build the blocking clause
   v = &ctx->aux_vector;
@@ -6631,10 +6631,10 @@ int32_t assert_blocking_clause(context_t *ctx) {
   code = CTX_NO_ERROR;
   if (n == 0) {
     code = TRIVIALLY_UNSAT;
-    ctx->core->status = STATUS_UNSAT;
+    ctx->core->status = SMT_STATUS_UNSAT;
   }
 
-  assert(n == 0 || smt_status(ctx->core) == STATUS_IDLE);
+  assert(n == 0 || smt_status(ctx->core) == SMT_STATUS_IDLE);
 
   return code;
 }

--- a/src/context/context.h
+++ b/src/context/context.h
@@ -205,8 +205,8 @@ extern int32_t assert_blocking_clause(context_t *ctx);
  * - parameters = search and heuristic parameters to use
  * - if parameters is NULL, the default values are used
  *
- * return status: either STATUS_UNSAT, STATUS_SAT, STATUS_UNKNOWN,
- * STATUS_INTERRUPTED (these codes are defined in smt_core.h)
+ * return status: either SMT_STATUS_UNSAT, SMT_STATUS_SAT, SMT_STATUS_UNKNOWN,
+ * SMT_STATUS_INTERRUPTED (these codes are defined in smt_core.h)
  */
 extern smt_status_t check_context(context_t *ctx, const param_t *parameters);
 
@@ -218,10 +218,10 @@ extern smt_status_t check_context(context_t *ctx, const param_t *parameters);
  * - a = array of n literals = n assumptions
  * - each a[i] must be defined in ctx->core
  *
- * return status: either STATUS_UNSAT, STATUS_SAT, STATUS_UNKNOWN,
- * STATUS_INTERRUPTED
+ * return status: either SMT_STATUS_UNSAT, SMT_STATUS_SAT, SMT_STATUS_UNKNOWN,
+ * SMT_STATUS_INTERRUPTED
  *
- * If status is STATUS_UNSAT then the assumptions are inconsistent
+ * If status is SMT_STATUS_UNSAT then the assumptions are inconsistent
  */
 extern smt_status_t check_context_with_assumptions(context_t *ctx, const param_t *parameters, uint32_t n, const literal_t *a);
 
@@ -234,16 +234,16 @@ extern smt_status_t check_context_with_assumptions(context_t *ctx, const param_t
  * - model = model to assume
  * - t = variables to use from the model (size = n)
  *
- * return status: either STATUS_UNSAT, STATUS_SAT, STATUS_UNKNOWN,
- * STATUS_INTERRUPTED
+ * return status: either SMT_STATUS_UNSAT, SMT_STATUS_SAT, SMT_STATUS_UNKNOWN,
+ * SMT_STATUS_INTERRUPTED
  *
- * If status is STATUS_UNSAT then the context and model are inconsistent
+ * If status is SMT_STATUS_UNSAT then the context and model are inconsistent
  */
 extern smt_status_t check_context_with_model(context_t *ctx, const param_t *params, model_t* mdl, uint32_t n, const term_t t[]);
 
 
 /*
- * Build a model: the context's status must be STATUS_SAT or STATUS_UNKNOWN
+ * Build a model: the context's status must be SMT_STATUS_SAT or SMT_STATUS_UNKNOWN
  * - model must be initialized (and empty)
  * - the model maps a value to every uninterpreted terms present in ctx's
  *   internalization tables
@@ -268,7 +268,7 @@ extern void clean_solver_models(context_t *ctx);
 
 
 /*
- * Build an unsat core: the context's status must be STATUS_UNSAT
+ * Build an unsat core: the context's status must be SMT_STATUS_UNSAT
  * - the unsat core is returned in vector *v
  * - if there are no assumption, the core is empty
  * - otherwise, the core is constructed from the bad_assumption
@@ -322,8 +322,8 @@ extern void context_clear(context_t *ctx);
  *   is restored to what it was at the start of search
  * - otherwise, this does nothing.
  *
- * On exit, the context's status can be either STATUS_IDLE
- * (if assumptions were removed) or STATUS_UNSAT otherwise.
+ * On exit, the context's status can be either SMT_STATUS_IDLE
+ * (if assumptions were removed) or SMT_STATUS_UNSAT otherwise.
  *
  * NOTE: Call this before context_pop(ctx) if the context status
  * is unsat.
@@ -429,12 +429,12 @@ extern int32_t context_process_formulas(context_t *ctx, uint32_t n, term_t *f);
 
 /*
  * Read the status: returns one of
- *  STATUS_IDLE        (before check_context)
- *  STATUS_SEARCHING   (during check_context)
- *  STATUS_UNKNOWN
- *  STATUS_SAT
- *  STATUS_UNSAT
- *  STATUS_INTERRUPTED
+ *  SMT_STATUS_IDLE        (before check_context)
+ *  SMT_STATUS_SEARCHING   (during check_context)
+ *  SMT_STATUS_UNKNOWN
+ *  SMT_STATUS_SAT
+ *  SMT_STATUS_UNSAT
+ *  SMT_STATUS_INTERRUPTED
  */
 static inline smt_status_t context_status(context_t *ctx) {
   if (ctx->arch == CTX_ARCH_MCSAT) {

--- a/src/context/context_solver.c
+++ b/src/context/context_solver.c
@@ -149,13 +149,13 @@ static void search(smt_core_t *core, uint32_t conflict_bound, uint32_t *reduce_t
   uint32_t r_threshold;
   literal_t l;
 
-  assert(smt_status(core) == STATUS_SEARCHING || smt_status(core) == STATUS_INTERRUPTED);
+  assert(smt_status(core) == SMT_STATUS_SEARCHING || smt_status(core) == SMT_STATUS_INTERRUPTED);
 
   max_conflicts = num_conflicts(core) + conflict_bound;
   r_threshold = *reduce_threshold;
 
   smt_process(core);
-  while (smt_status(core) == STATUS_SEARCHING && num_conflicts(core) <= max_conflicts) {
+  while (smt_status(core) == SMT_STATUS_SEARCHING && num_conflicts(core) <= max_conflicts) {
     // reduce heuristic
     if (num_learned_clauses(core) >= r_threshold) {
       deletions = core->stats.learned_clauses_deleted;
@@ -203,13 +203,13 @@ static void luby_search(smt_core_t *core, uint32_t conflict_bound, uint32_t *red
   uint32_t r_threshold;
   literal_t l;
 
-  assert(smt_status(core) == STATUS_SEARCHING || smt_status(core) == STATUS_INTERRUPTED);
+  assert(smt_status(core) == SMT_STATUS_SEARCHING || smt_status(core) == SMT_STATUS_INTERRUPTED);
 
   max_conflicts = num_conflicts(core) + conflict_bound;
   r_threshold = *reduce_threshold;
 
   smt_bounded_process(core, max_conflicts);
-  while (smt_status(core) == STATUS_SEARCHING && num_conflicts(core) < max_conflicts) {
+  while (smt_status(core) == SMT_STATUS_SEARCHING && num_conflicts(core) < max_conflicts) {
     // reduce heuristic
     if (num_learned_clauses(core) >= r_threshold) {
       deletions = core->stats.learned_clauses_deleted;
@@ -262,13 +262,13 @@ static void special_search(smt_core_t *core, uint32_t conflict_bound, uint32_t *
   uint32_t r_threshold;
   literal_t l;
 
-  assert(smt_status(core) == STATUS_SEARCHING || smt_status(core) == STATUS_INTERRUPTED);
+  assert(smt_status(core) == SMT_STATUS_SEARCHING || smt_status(core) == SMT_STATUS_INTERRUPTED);
 
   max_conflicts = num_conflicts(core) + conflict_bound;
   r_threshold = *reduce_threshold;
 
   smt_process(core);
-  while (smt_status(core) == STATUS_SEARCHING && num_conflicts(core) <= max_conflicts) {
+  while (smt_status(core) == SMT_STATUS_SEARCHING && num_conflicts(core) <= max_conflicts) {
     // reduce heuristic
     if (num_learned_clauses(core) >= r_threshold) {
       deletions = core->stats.learned_clauses_deleted;
@@ -394,7 +394,7 @@ static void solve(smt_core_t *core, const param_t *params, uint32_t n, const lit
   // initialize then do a propagation + simplification step.
   start_search(core, n, a);
   trace_start(core);
-  if (smt_status(core) == STATUS_SEARCHING) {
+  if (smt_status(core) == SMT_STATUS_SEARCHING) {
     // loop
     for (;;) {
       switch (params->branching) {
@@ -422,7 +422,7 @@ static void solve(smt_core_t *core, const param_t *params, uint32_t n, const lit
         break;
       }
 
-      if (smt_status(core) != STATUS_SEARCHING) break;
+      if (smt_status(core) != SMT_STATUS_SEARCHING) break;
 
       smt_restart(core);
       //      smt_partial_restart_var(core);
@@ -575,7 +575,7 @@ smt_status_t check_context(context_t *ctx, const param_t *params) {
 
   core = ctx->core;
   stat = smt_status(core);
-  if (stat == STATUS_IDLE) {
+  if (stat == SMT_STATUS_IDLE) {
     // clean state: the search can proceed
     context_set_search_parameters(ctx, params);
     solve(core, params, 0, NULL);
@@ -596,7 +596,7 @@ smt_status_t check_context_with_assumptions(context_t *ctx, const param_t *param
 
   core = ctx->core;
   stat = smt_status(core);
-  if (stat == STATUS_IDLE) {
+  if (stat == SMT_STATUS_IDLE) {
     // clean state
     if (params == NULL) {
       params = get_default_params();
@@ -619,13 +619,13 @@ smt_status_t check_context_with_model(context_t *ctx, const param_t *params, mod
   assert(ctx->mcsat != NULL);
 
   stat = mcsat_status(ctx->mcsat);
-  if (stat == STATUS_IDLE) {
+  if (stat == SMT_STATUS_IDLE) {
     mcsat_solve(ctx->mcsat, params, mdl, n, t);
     stat = mcsat_status(ctx->mcsat);
 
     // BD: this looks wrong. We shouldn't call clear yet.
-    // we want the status to remain STATUS_UNSAT until the next call to check or assert.
-    //    if (n > 0 && stat == STATUS_UNSAT && context_supports_multichecks(ctx)) {
+    // we want the status to remain SMT_STATUS_UNSAT until the next call to check or assert.
+    //    if (n > 0 && stat == SMT_STATUS_UNSAT && context_supports_multichecks(ctx)) {
     //      context_clear(ctx);
     //    }
   }
@@ -660,17 +660,17 @@ smt_status_t precheck_context(context_t *ctx) {
   core = ctx->core;
 
   stat = smt_status(core);
-  if (stat == STATUS_IDLE) {
+  if (stat == SMT_STATUS_IDLE) {
     start_search(core, 0, NULL);
     smt_process(core);
     stat = smt_status(core);
 
-    assert(stat == STATUS_UNSAT || stat == STATUS_SEARCHING ||
-	   stat == STATUS_INTERRUPTED);
+    assert(stat == SMT_STATUS_UNSAT || stat == SMT_STATUS_SEARCHING ||
+	   stat == SMT_STATUS_INTERRUPTED);
 
-    if (stat == STATUS_SEARCHING) {
+    if (stat == SMT_STATUS_SEARCHING) {
       end_search_unknown(core);
-      stat = STATUS_UNKNOWN;
+      stat = SMT_STATUS_UNKNOWN;
     }
   }
 
@@ -697,17 +697,17 @@ smt_status_t check_with_delegate(context_t *ctx, const char *sat_solver, uint32_
   core = ctx->core;
 
   stat = smt_status(core);
-  if (stat == STATUS_IDLE) {
+  if (stat == SMT_STATUS_IDLE) {
     start_search(core, 0, NULL);
     smt_process(core);
     stat = smt_status(core);
 
-    assert(stat == STATUS_UNSAT || stat == STATUS_SEARCHING ||
-	   stat == STATUS_INTERRUPTED);
+    assert(stat == SMT_STATUS_UNSAT || stat == SMT_STATUS_SEARCHING ||
+	   stat == SMT_STATUS_INTERRUPTED);
 
-    if (stat == STATUS_SEARCHING) {
+    if (stat == SMT_STATUS_SEARCHING) {
       if (smt_easy_sat(core)) {
-	stat = STATUS_SAT;
+	stat = SMT_STATUS_SAT;
       } else {
 	// call the delegate
 	init_delegate(&delegate, sat_solver, num_vars(core));
@@ -715,7 +715,7 @@ smt_status_t check_with_delegate(context_t *ctx, const char *sat_solver, uint32_
 
 	stat = solve_with_delegate(&delegate, core);
 	set_smt_status(core, stat);
-	if (stat == STATUS_SAT) {
+	if (stat == SMT_STATUS_SAT) {
 	  for (x=0; x<num_vars(core); x++) {
 	    v = delegate_get_value(&delegate, x);
 	    set_bvar_value(core, x, v);
@@ -757,15 +757,15 @@ int32_t bitblast_then_export_to_dimacs(context_t *ctx, const char *filename, smt
 
   code = 0;
   stat = smt_status(core);
-  if (stat == STATUS_IDLE) {
+  if (stat == SMT_STATUS_IDLE) {
     start_search(core, 0, NULL);
     smt_process(core);
     stat = smt_status(core);
 
-    assert(stat == STATUS_UNSAT || stat == STATUS_SEARCHING ||
-	   stat == STATUS_INTERRUPTED);
+    assert(stat == SMT_STATUS_UNSAT || stat == SMT_STATUS_SEARCHING ||
+	   stat == SMT_STATUS_INTERRUPTED);
 
-    if (stat == STATUS_SEARCHING) {
+    if (stat == SMT_STATUS_SEARCHING) {
       code = 1;
       f = fopen(filename, "w");
       if (f == NULL) {
@@ -814,17 +814,17 @@ int32_t process_then_export_to_dimacs(context_t *ctx, const char *filename, smt_
 
   code = 0;
   stat = smt_status(core);
-  if (stat == STATUS_IDLE) {
+  if (stat == SMT_STATUS_IDLE) {
     start_search(core, 0, NULL);
     smt_process(core);
     stat = smt_status(core);
 
-    assert(stat == STATUS_UNSAT || stat == STATUS_SEARCHING ||
-	   stat == STATUS_INTERRUPTED);
+    assert(stat == SMT_STATUS_UNSAT || stat == SMT_STATUS_SEARCHING ||
+	   stat == SMT_STATUS_INTERRUPTED);
 
-    if (stat == STATUS_SEARCHING) {
+    if (stat == SMT_STATUS_SEARCHING) {
       if (smt_easy_sat(core)) {
-	stat = STATUS_SAT;
+	stat = SMT_STATUS_SAT;
       } else {
 	// call the delegate
 	init_delegate(&delegate, "y2sat", num_vars(core));
@@ -832,12 +832,12 @@ int32_t process_then_export_to_dimacs(context_t *ctx, const char *filename, smt_
 
 	stat = preprocess_with_delegate(&delegate, core);
 	set_smt_status(core, stat);
-	if (stat == STATUS_SAT) {
+	if (stat == SMT_STATUS_SAT) {
 	  for (x=0; x<num_vars(core); x++) {
 	    v = delegate_get_value(&delegate, x);
 	    set_bvar_value(core, x, v);
 	  }
-	} else if (stat == STATUS_UNKNOWN) {
+	} else if (stat == SMT_STATUS_UNKNOWN) {
 	  code = 1;
 	  f = fopen(filename, "w");
 	  if (f == NULL) {
@@ -1056,7 +1056,7 @@ void build_model(model_t *model, context_t *ctx) {
   uint32_t i, n;
   term_t t;
 
-  assert(smt_status(ctx->core) == STATUS_SAT || smt_status(ctx->core) == STATUS_UNKNOWN || mcsat_status(ctx->mcsat) == STATUS_SAT);
+  assert(smt_status(ctx->core) == SMT_STATUS_SAT || smt_status(ctx->core) == SMT_STATUS_UNKNOWN || mcsat_status(ctx->mcsat) == SMT_STATUS_SAT);
 
   /*
    * First build assignments in the satellite solvers
@@ -1187,7 +1187,7 @@ void context_build_unsat_core(context_t *ctx, ivector_t *v) {
   term_t t;
 
   core = ctx->core;
-  assert(core != NULL && core->status == STATUS_UNSAT);
+  assert(core != NULL && core->status == SMT_STATUS_UNSAT);
   build_unsat_core(core, v);
 
   // convert from literals to terms

--- a/src/frontend/common/assumptions_and_core.c
+++ b/src/frontend/common/assumptions_and_core.c
@@ -37,7 +37,7 @@ assumptions_and_core_t *new_assumptions(term_table_t *terms) {
   init_assumption_table(&a->table);
   init_ivector(&a->assumptions, 0);
   init_ivector(&a->core, 0);
-  a->status = STATUS_IDLE;
+  a->status = SMT_STATUS_IDLE;
   return a;
 }
 

--- a/src/frontend/smt2/smt2_commands.c
+++ b/src/frontend/smt2/smt2_commands.c
@@ -269,15 +269,15 @@ static void bitblast_then_export(context_t *ctx, const char *s) {
 
   stat = precheck_context(ctx);
   switch (stat) {
-  case STATUS_UNKNOWN:
+  case SMT_STATUS_UNKNOWN:
     do_export(ctx, s);
     break;
 
-  case STATUS_SAT:
-  case STATUS_UNSAT:
+  case SMT_STATUS_SAT:
+  case SMT_STATUS_UNSAT:
     break;
 
-  case STATUS_INTERRUPTED:
+  case SMT_STATUS_INTERRUPTED:
     fprintf(stderr, "Export to dimacs interrupted\n");
     break;
 
@@ -666,9 +666,9 @@ static smt_status_t check_with_assumptions(context_t *ctx, const param_t *params
   uint32_t i;
 
   // if ctx is already unsat, the core is empty
-  if (context_status(ctx) == STATUS_UNSAT) {
+  if (context_status(ctx) == SMT_STATUS_UNSAT) {
     ivector_reset(core);
-    return STATUS_UNSAT;
+    return SMT_STATUS_UNSAT;
   }
 
   // If MCSAT use the model solving command
@@ -699,14 +699,14 @@ static smt_status_t check_with_assumptions(context_t *ctx, const param_t *params
     if (l < 0) {
       // error when processing term a[i]
       yices_internalization_error(l);
-      status = STATUS_ERROR;
+      status = SMT_STATUS_ERROR;
       goto done;
     }
     ivector_push(&assumptions, l);
   }
 
   status = check_context_with_assumptions(ctx, params, n, assumptions.data);
-  if (status == STATUS_UNSAT) {
+  if (status == SMT_STATUS_UNSAT) {
     context_build_unsat_core(ctx, core);
   }
 
@@ -1548,14 +1548,14 @@ static void show_status(smt_status_t status) {
  */
 static void report_status(smt2_globals_t *g, smt_status_t status) {
   switch (status) {
-  case STATUS_UNKNOWN:
-  case STATUS_SAT:
-  case STATUS_UNSAT:
-  case STATUS_INTERRUPTED:
+  case SMT_STATUS_UNKNOWN:
+  case SMT_STATUS_SAT:
+  case SMT_STATUS_UNSAT:
+  case SMT_STATUS_INTERRUPTED:
     show_status(status);
     break;
 
-  case STATUS_ERROR:
+  case SMT_STATUS_ERROR:
     print_yices_error(true);
     break;
 
@@ -2663,7 +2663,7 @@ static void timeout_handler(void *data) {
   g = data;
   if (g->efmode && g->ef_client.efsolver != NULL && g->ef_client.efsolver->status == EF_STATUS_SEARCHING) {
     ef_solver_stop_search(g->ef_client.efsolver);
-  } else if (g->ctx != NULL && context_status(g->ctx) == STATUS_SEARCHING) {
+  } else if (g->ctx != NULL && context_status(g->ctx) == SMT_STATUS_SEARCHING) {
     context_stop_search(g->ctx);
   }
 }
@@ -2695,15 +2695,15 @@ static smt_status_t check_sat_with_timeout(smt2_globals_t *g, const param_t *par
   /*
    * Attempt to cleanly recover from interrupt
    */
-  if (stat == STATUS_INTERRUPTED) {
+  if (stat == SMT_STATUS_INTERRUPTED) {
     trace_printf(g->tracer, 2, "(check-sat: interrupted)\n");
     g->interrupted = true;
     if (context_get_mode(g->ctx) == CTX_MODE_INTERACTIVE) {
       context_cleanup(g->ctx);
-      assert(context_status(g->ctx) == STATUS_IDLE);
+      assert(context_status(g->ctx) == SMT_STATUS_IDLE);
     }
     // we don't want to report "interrupted" that's not SMT2 compliant
-    stat = STATUS_UNKNOWN;
+    stat = SMT_STATUS_UNKNOWN;
   }
 
   return stat;
@@ -2741,15 +2741,15 @@ static smt_status_t check_sat_with_assumptions(smt2_globals_t *g, const param_t 
   /*
    * Attempt to cleanly recover from interrupt
    */
-  if (stat == STATUS_INTERRUPTED) {
+  if (stat == SMT_STATUS_INTERRUPTED) {
     trace_printf(g->tracer, 2, "(check-sat-assuming: interrupted)\n");
     g->interrupted = true;
     if (context_get_mode(g->ctx) == CTX_MODE_INTERACTIVE) {
       context_cleanup(g->ctx);
-      assert(context_status(g->ctx) == STATUS_IDLE);
+      assert(context_status(g->ctx) == SMT_STATUS_IDLE);
     }
     // we don't want to report "interrupted" that's not SMT2 compliant
-    stat = STATUS_UNKNOWN;
+    stat = SMT_STATUS_UNKNOWN;
   }
 
   return stat;
@@ -2787,15 +2787,15 @@ static smt_status_t check_sat_with_model(smt2_globals_t *g, const param_t *param
   /*
    * Attempt to cleanly recover from interrupt
    */
-  if (stat == STATUS_INTERRUPTED) {
+  if (stat == SMT_STATUS_INTERRUPTED) {
     trace_printf(g->tracer, 2, "(check-sat-assuming-model: interrupted)\n");
     g->interrupted = true;
     if (context_get_mode(g->ctx) == CTX_MODE_INTERACTIVE) {
       context_cleanup(g->ctx);
-      assert(context_status(g->ctx) == STATUS_IDLE);
+      assert(context_status(g->ctx) == SMT_STATUS_IDLE);
     }
     // we don't want to report "interrupted" that's not SMT2 compliant
-    stat = STATUS_UNKNOWN;
+    stat = SMT_STATUS_UNKNOWN;
   }
 
   g->check_with_model_status = stat;
@@ -3039,13 +3039,13 @@ static void check_delayed_assertions(smt2_globals_t *g, bool report) {
   if (g->trivially_unsat) {
     trace_printf(g->tracer, 3, "(check-sat: trivially unsat)\n");
     if (report)
-      report_status(g, STATUS_UNSAT);
+      report_status(g, SMT_STATUS_UNSAT);
   } else if (trivially_true_assertions(g->assertions.data, g->assertions.size, &model)) {
     trace_printf(g->tracer, 3, "(check-sat: trivially true)\n");
     g->trivially_sat = true;
     g->model = model;
     if (report)
-      report_status(g, STATUS_SAT);
+      report_status(g, SMT_STATUS_SAT);
   } else {
     /*
      * check for mislabeled benchmarks: some benchmarks
@@ -3093,7 +3093,7 @@ static void check_delayed_assertions(smt2_globals_t *g, bool report) {
 	    perror(g->dimacs_file);
 	    exit(YICES_EXIT_SYSTEM_ERROR);
 	  }
-	  if (status == STATUS_UNKNOWN) {
+	  if (status == SMT_STATUS_UNKNOWN) {
 	    // don't print anything
 	    return;
 	  }
@@ -3159,7 +3159,7 @@ static void validate_unsat_core(smt2_globals_t *g) {
   int32_t code;
   smt_status_t status;
 
-  if (g->unsat_core->status == STATUS_UNSAT) {
+  if (g->unsat_core->status == SMT_STATUS_UNSAT) {
     saved_context = g->ctx;
     g->ctx = NULL;
     init_smt2_context(g);
@@ -3175,7 +3175,7 @@ static void validate_unsat_core(smt2_globals_t *g) {
       fflush(stdout);
     } else {
       status = check_context(g->ctx, &g->parameters);
-      if (status != STATUS_UNSAT) {
+      if (status != SMT_STATUS_UNSAT) {
         printf("**** BUG: INVALID UNSAT CORE ****\n");
         fflush(stdout);
       }
@@ -3201,8 +3201,8 @@ static void delayed_assertions_unsat_core(smt2_globals_t *g) {
   g->unsat_core = collect_named_assertions(g);
   if (g->trivially_unsat) {
     // the core is empty
-    g->unsat_core->status = STATUS_UNSAT;
-    report_status(g, STATUS_UNSAT);
+    g->unsat_core->status = SMT_STATUS_UNSAT;
+    report_status(g, SMT_STATUS_UNSAT);
   } else {
     init_smt2_context(g);
     code = yices_assert_formulas(g->ctx, g->assertions.size, g->assertions.data);
@@ -3220,7 +3220,7 @@ static void delayed_assertions_unsat_core(smt2_globals_t *g) {
     //    validate_unsat_core(g);
     report_status(g, status);
 
-    if (status == STATUS_ERROR) {
+    if (status == SMT_STATUS_ERROR) {
       free_assumptions(g->unsat_core);
       g->unsat_core = NULL;
       done = true;
@@ -3244,8 +3244,8 @@ static void check_delayed_assertions_assuming(smt2_globals_t *g, uint32_t n, sig
     g->unsat_assumptions = assumptions;
     if (g->trivially_unsat) {
       // list of unsat assumption is empty
-      assumptions->status = STATUS_UNSAT;
-      report_status(g, STATUS_UNSAT);
+      assumptions->status = SMT_STATUS_UNSAT;
+      report_status(g, SMT_STATUS_UNSAT);
     } else {
       init_smt2_context(g);
       code = yices_assert_formulas(g->ctx, g->assertions.size, g->assertions.data);
@@ -3262,7 +3262,7 @@ static void check_delayed_assertions_assuming(smt2_globals_t *g, uint32_t n, sig
       status = check_sat_with_assumptions(g, &g->parameters, assumptions);
       report_status(g, status);
 
-      if (status == STATUS_ERROR) {
+      if (status == SMT_STATUS_ERROR) {
         // cleanup
         free_assumptions(assumptions);
         g->unsat_assumptions = NULL;
@@ -3282,8 +3282,8 @@ static void check_delayed_assertions_assuming_model(smt2_globals_t *g, uint32_t 
   g->frozen = true;
   if (g->trivially_unsat) {
     // list of unsat assumption is empty
-    report_status(g, STATUS_UNSAT);
-    g->check_with_model_status = STATUS_UNSAT;
+    report_status(g, SMT_STATUS_UNSAT);
+    g->check_with_model_status = SMT_STATUS_UNSAT;
   } else {
     init_smt2_context(g);
     code = yices_assert_formulas(g->ctx, g->assertions.size, g->assertions.data);
@@ -3371,28 +3371,28 @@ static void cleanup_context(smt2_globals_t *g) {
     free_assumptions(g->unsat_assumptions);
     g->unsat_assumptions  = NULL;
   }
-  g->check_with_model_status = STATUS_IDLE;
+  g->check_with_model_status = SMT_STATUS_IDLE;
 
   switch (context_status(g->ctx)) {
-  case STATUS_UNKNOWN:
-  case STATUS_SAT:
+  case SMT_STATUS_UNKNOWN:
+  case SMT_STATUS_SAT:
     // return to IDLE
     context_clear(g->ctx);
-    assert(context_status(g->ctx) == STATUS_IDLE);
+    assert(context_status(g->ctx) == SMT_STATUS_IDLE);
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     // try to to remove assumptions
     context_clear_unsat(g->ctx);
-    assert (context_status(g->ctx) == STATUS_IDLE ||
-            context_status(g->ctx) == STATUS_UNSAT);
+    assert (context_status(g->ctx) == SMT_STATUS_IDLE ||
+            context_status(g->ctx) == SMT_STATUS_UNSAT);
     break;
 
-  case STATUS_IDLE:
+  case SMT_STATUS_IDLE:
     break;
 
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
   default:
     bad_status_bug(g->err);
     break;
@@ -3428,7 +3428,7 @@ static void add_assertion(smt2_globals_t *g, term_t t) {
   //  show_assertion(g, t);
 
   switch (context_status(g->ctx)) {
-  case STATUS_IDLE:
+  case SMT_STATUS_IDLE:
     code = assert_formula(g->ctx, t);
     if (code < 0) {
       print_internalization_error(code);
@@ -3437,7 +3437,7 @@ static void add_assertion(smt2_globals_t *g, term_t t) {
     }
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     /*
      * Ignore the assertion. We don't try to check whether
      * t is a correct assertion (e.g., no free variables in t).
@@ -3445,10 +3445,10 @@ static void add_assertion(smt2_globals_t *g, term_t t) {
     report_success();
     break;
 
-  case STATUS_UNKNOWN:
-  case STATUS_SAT:
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
+  case SMT_STATUS_UNKNOWN:
+  case SMT_STATUS_SAT:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
   default:
     bad_status_bug(g->err);
     break;
@@ -3465,7 +3465,7 @@ static void ctx_check_sat(smt2_globals_t *g) {
 
   assert(g->ctx != NULL && context_supports_pushpop(g->ctx));
 
-  if (g->unsat_assumptions != NULL || g->check_with_model_status != STATUS_IDLE) {
+  if (g->unsat_assumptions != NULL || g->check_with_model_status != SMT_STATUS_IDLE) {
     /*
      * the context's status was based on the assumptions or assumed model
      * we reset everything here to be safe.
@@ -3475,14 +3475,14 @@ static void ctx_check_sat(smt2_globals_t *g) {
 
   stat = context_status(g->ctx);
   switch (stat) {
-  case STATUS_UNKNOWN:
-  case STATUS_UNSAT:
-  case STATUS_SAT:
+  case SMT_STATUS_UNKNOWN:
+  case SMT_STATUS_UNSAT:
+  case SMT_STATUS_SAT:
     // already solved: print the status
     show_status(stat);
     break;
 
-  case STATUS_IDLE:
+  case SMT_STATUS_IDLE:
     // change the seed if needed
     if (g->random_seed != 0) {
       g->parameters.random_seed = g->random_seed;
@@ -3491,8 +3491,8 @@ static void ctx_check_sat(smt2_globals_t *g) {
     report_status(g, stat);
     break;
 
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
   default:
     bad_status_bug(g->err);
     break;
@@ -3517,31 +3517,31 @@ static void ctx_unsat_core(smt2_globals_t *g) {
     g->unsat_core = collect_named_assertions(g);
     stat = context_status(g->ctx);
     switch (stat) {
-    case STATUS_UNSAT:
+    case SMT_STATUS_UNSAT:
       // already solved: store the status and print it
       // the unsat core is empty
       g->unsat_core->status = stat;
       show_status(stat);
       break;
 
-    case STATUS_IDLE:
+    case SMT_STATUS_IDLE:
       // change the seed if needed
       if (g->random_seed != 0) {
         g->parameters.random_seed = g->random_seed;
       }
       stat = check_sat_with_assumptions(g, &g->parameters, g->unsat_core);
       report_status(g, stat);
-      if (stat == STATUS_ERROR) {
+      if (stat == SMT_STATUS_ERROR) {
         free_assumptions(g->unsat_core);
         g->unsat_core = NULL;
       }
       break;
 
-    case STATUS_SAT:
-    case STATUS_UNKNOWN:
+    case SMT_STATUS_SAT:
+    case SMT_STATUS_UNKNOWN:
       // this should not happen.
-    case STATUS_SEARCHING:
-    case STATUS_INTERRUPTED:
+    case SMT_STATUS_SEARCHING:
+    case SMT_STATUS_INTERRUPTED:
     default:
       bad_status_bug(g->err);
       break;
@@ -3566,29 +3566,29 @@ static void ctx_check_sat_assuming(smt2_globals_t *g, uint32_t n, signed_symbol_
   if (assumptions != NULL) {
     g->unsat_assumptions = assumptions;
     switch (context_status(g->ctx)) {
-    case STATUS_IDLE:
+    case SMT_STATUS_IDLE:
       if (g->random_seed != 0) {
         g->parameters.random_seed = g->random_seed;
       }
       status = check_sat_with_assumptions(g, &g->parameters, assumptions);
       report_status(g, status);
-      if (status == STATUS_ERROR) {
+      if (status == SMT_STATUS_ERROR) {
         free_assumptions(assumptions);
         g->unsat_assumptions = NULL;
         done = true;
       }
       break;
 
-    case STATUS_UNSAT:
+    case SMT_STATUS_UNSAT:
       // the context is already unsat so the list of unsat assumptions is empty
-      assumptions->status = STATUS_UNSAT;
-      show_status(STATUS_UNSAT);
+      assumptions->status = SMT_STATUS_UNSAT;
+      show_status(SMT_STATUS_UNSAT);
       break;
 
-    case STATUS_UNKNOWN:
-    case STATUS_SAT:
-    case STATUS_SEARCHING:
-    case STATUS_INTERRUPTED:
+    case SMT_STATUS_UNKNOWN:
+    case SMT_STATUS_SAT:
+    case SMT_STATUS_SEARCHING:
+    case SMT_STATUS_INTERRUPTED:
     default:
       bad_status_bug(g->err);
       break;
@@ -3605,7 +3605,7 @@ static void ctx_check_sat_assuming_model(smt2_globals_t *g, uint32_t n, const te
   cleanup_context(g);
 
   switch (context_status(g->ctx)) {
-  case STATUS_IDLE:
+  case SMT_STATUS_IDLE:
     if (g->random_seed != 0) {
       g->parameters.random_seed = g->random_seed;
     }
@@ -3613,14 +3613,14 @@ static void ctx_check_sat_assuming_model(smt2_globals_t *g, uint32_t n, const te
     report_status(g, status);
     break;
 
-  case STATUS_UNSAT:
-    show_status(STATUS_UNSAT);
+  case SMT_STATUS_UNSAT:
+    show_status(SMT_STATUS_UNSAT);
     break;
 
-  case STATUS_UNKNOWN:
-  case STATUS_SAT:
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
+  case SMT_STATUS_UNKNOWN:
+  case SMT_STATUS_SAT:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
   default:
     bad_status_bug(g->err);
     break;
@@ -3637,18 +3637,18 @@ static void ctx_push(smt2_globals_t *g) {
   cleanup_context(g);
 
   switch (context_status(g->ctx)) {
-  case STATUS_IDLE:
+  case SMT_STATUS_IDLE:
     context_push(g->ctx);
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     g->pushes_after_unsat ++;
     break;
 
-  case STATUS_UNKNOWN:
-  case STATUS_SAT:
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
+  case SMT_STATUS_UNKNOWN:
+  case SMT_STATUS_SAT:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
   default:
     bad_status_bug(g->err);
     break;
@@ -3665,11 +3665,11 @@ static void ctx_pop(smt2_globals_t *g) {
   cleanup_context(g);
 
   switch (context_status(g->ctx)) {
-  case STATUS_IDLE:
+  case SMT_STATUS_IDLE:
     context_pop(g->ctx);
     break;
 
-  case STATUS_UNSAT:
+  case SMT_STATUS_UNSAT:
     if (g->pushes_after_unsat > 0) {
       g->pushes_after_unsat --;
     } else {
@@ -3678,10 +3678,10 @@ static void ctx_pop(smt2_globals_t *g) {
     }
     break;
 
-  case STATUS_UNKNOWN:
-  case STATUS_SAT:
-  case STATUS_SEARCHING:
-  case STATUS_INTERRUPTED:
+  case SMT_STATUS_UNKNOWN:
+  case SMT_STATUS_SAT:
+  case SMT_STATUS_SEARCHING:
+  case SMT_STATUS_INTERRUPTED:
   default:
     bad_status_bug(g->err);
     break;
@@ -3722,24 +3722,24 @@ static model_t *get_model(smt2_globals_t *g) {
     } else {
       // context exists
       switch (context_status(g->ctx)) {
-      case STATUS_UNKNOWN:
-      case STATUS_SAT:
+      case SMT_STATUS_UNKNOWN:
+      case SMT_STATUS_SAT:
         mdl = yices_get_model(g->ctx, true);
         break;
 
-      case STATUS_UNSAT:
+      case SMT_STATUS_UNSAT:
         print_error("the context is unsatisfiable");
         break;
 
-      case STATUS_IDLE:
+      case SMT_STATUS_IDLE:
         print_error("can't build a model. Call (check-sat) first");
         break;
 
-      case STATUS_INTERRUPTED:
+      case SMT_STATUS_INTERRUPTED:
 	print_error("the search was interrupted. No model is available");
 	break;
 
-      case STATUS_SEARCHING:
+      case SMT_STATUS_SEARCHING:
       default:
         print_out("BUG: unexpected context status");
         freport_bug(__smt2_globals.err, "BUG: unexpected context status");
@@ -4127,26 +4127,26 @@ static void show_assignment(smt2_globals_t *g) {
 
   } else {
     switch (context_status(g->ctx)) {
-    case STATUS_UNKNOWN:
-    case STATUS_SAT:
+    case SMT_STATUS_UNKNOWN:
+    case SMT_STATUS_SAT:
       init_pretty_printer(&printer, g);
       print_assignment(&printer, g->ctx, &g->named_bools);
       delete_smt2_pp(&printer, true);
       break;
 
-    case STATUS_UNSAT:
+    case SMT_STATUS_UNSAT:
       print_error("the context is unsatisfiable");
       break;
 
-    case STATUS_IDLE:
+    case SMT_STATUS_IDLE:
       print_error("can't build the assignment. Call (check-sat) first");
       break;
 
-    case STATUS_INTERRUPTED:
+    case SMT_STATUS_INTERRUPTED:
       print_error("can't build the assignment. The search was interrupted");
       break;
 
-    case STATUS_SEARCHING:
+    case SMT_STATUS_SEARCHING:
     default:
       print_out("BUG: unexpected context status");
       freport_bug(__smt2_globals.err, "BUG: unexpected context status");
@@ -4210,24 +4210,24 @@ static void show_unsat_core(smt2_globals_t *g) {
       print_error("Can't build an unsat core. Call (check-sat) first");
     } else {
       switch (unsat_core->status) {
-      case STATUS_UNKNOWN:
-      case STATUS_SAT:
+      case SMT_STATUS_UNKNOWN:
+      case SMT_STATUS_SAT:
         print_error("No unsat core. The context is satisfiable");
         break;
 
-      case STATUS_UNSAT:
+      case SMT_STATUS_UNSAT:
         init_pretty_printer(&printer, g);
         print_assumption_list(&printer, &unsat_core->table,
                               unsat_core->core.size, unsat_core->core.data);
         delete_smt2_pp(&printer, true);
         break;
 
-      case STATUS_INTERRUPTED:
+      case SMT_STATUS_INTERRUPTED:
 	print_error("No unsat core. The search was interrupted");
 	break;
 
-      case STATUS_IDLE:
-      case STATUS_SEARCHING:
+      case SMT_STATUS_IDLE:
+      case SMT_STATUS_SEARCHING:
       default:
         print_out("BUG: unexpected status in get-unsat-core");
         freport_bug(__smt2_globals.err, "BUG: unexpected status in get-unsat-core");
@@ -4252,24 +4252,24 @@ static void show_unsat_assumptions(smt2_globals_t *g) {
       print_error("Call (check-sat-assuming) first");
     } else {
       switch (unsat_assumptions->status) {
-      case STATUS_UNKNOWN:
-      case STATUS_SAT:
+      case SMT_STATUS_UNKNOWN:
+      case SMT_STATUS_SAT:
         print_error("No unsat assumptions. The context is satisfiable");
         break;
 
-      case STATUS_UNSAT:
+      case SMT_STATUS_UNSAT:
         init_pretty_printer(&printer, g);
         print_assumption_list(&printer, &unsat_assumptions->table,
                               unsat_assumptions->core.size, unsat_assumptions->core.data);
         delete_smt2_pp(&printer, true);
         break;
 
-      case STATUS_INTERRUPTED:
+      case SMT_STATUS_INTERRUPTED:
 	print_error("No unsat assumptions. The search was interrupted");
 	break;
 
-      case STATUS_IDLE:
-      case STATUS_SEARCHING:
+      case SMT_STATUS_IDLE:
+      case SMT_STATUS_SEARCHING:
       default:
         print_out("BUG: unexpected status in get-unsat-assumptions");
         freport_bug(__smt2_globals.err, "BUG: unexpected status in get-unsat-assumptions");
@@ -4289,7 +4289,7 @@ static void show_unsat_model_interpolant(smt2_globals_t *g) {
   if (!g->produce_unsat_model_interpolants) {
     print_error("not supported: :produce-unsat-model-interpolants is false");
   } else if (g->ctx == NULL) {
-    if (g->check_with_model_status == STATUS_UNSAT) {
+    if (g->check_with_model_status == SMT_STATUS_UNSAT) {
       print_out("false");
       flush_out();
     } else {
@@ -4297,15 +4297,15 @@ static void show_unsat_model_interpolant(smt2_globals_t *g) {
     }
   } else {
     switch (context_status(g->ctx)) {
-    case STATUS_SAT:
+    case SMT_STATUS_SAT:
       print_error("No model interpolant. The context is satisfiable");
       break;
 
-    case STATUS_UNKNOWN:
+    case SMT_STATUS_UNKNOWN:
       print_error("No model interpolant. The context is not knwon to be unsatisfiable");
       break;
 
-    case STATUS_UNSAT:
+    case SMT_STATUS_UNSAT:
       unsat_model_interpolant = context_get_unsat_model_interpolant(g->ctx);
       if (unsat_model_interpolant == NULL_TERM) {
 	print_error("Call (check-sat-assuming-model) first");
@@ -4316,15 +4316,15 @@ static void show_unsat_model_interpolant(smt2_globals_t *g) {
       }
       break;
 
-    case STATUS_IDLE:
+    case SMT_STATUS_IDLE:
       print_error("Call (check-sat-assuming-model) first");
       break;
 
-    case STATUS_INTERRUPTED:
+    case SMT_STATUS_INTERRUPTED:
       print_error("No model interpolant. Last call to check-sat timedout");
       break;
 
-    case STATUS_SEARCHING:
+    case SMT_STATUS_SEARCHING:
     default:
       print_out("BUG: unexpected status in get-unsat-model-interpolant");
       freport_bug(__smt2_globals.err, "BUG: unexpected status in get-unsat-model-interpolant");
@@ -4398,7 +4398,7 @@ static void check_stack(smt2_globals_t *g) {
       freport_bug(g->err, "Internal error: unexpected context status");
     }
 
-    if (g->pushes_after_unsat > 0 && context_status(g->ctx) != STATUS_UNSAT) {
+    if (g->pushes_after_unsat > 0 && context_status(g->ctx) != SMT_STATUS_UNSAT) {
       freport_bug(g->err, "Invalid stack: push_after_unsat is positive but context is not unsat");
     }
   }
@@ -4502,7 +4502,7 @@ static void explain_unknown_status(smt2_globals_t *g) {
       }
     } else {
       switch (context_status(g->ctx)) {
-      case STATUS_UNKNOWN:
+      case SMT_STATUS_UNKNOWN:
         if (g->interrupted) {
           print_kw_symbol_pair(":reason-unknown", "timeout");
         } else {
@@ -4511,20 +4511,20 @@ static void explain_unknown_status(smt2_globals_t *g) {
         flush_out();
         break;
 
-      case STATUS_SAT:
+      case SMT_STATUS_SAT:
         print_error("the context is satisfiable");
         break;
 
-      case STATUS_UNSAT:
+      case SMT_STATUS_UNSAT:
         print_error("the context is unsatisfiable");
         break;
 
-      case STATUS_IDLE:
+      case SMT_STATUS_IDLE:
         print_error("can't tell until you call (check-sat)");
         break;
 
-      case STATUS_SEARCHING:
-      case STATUS_INTERRUPTED:
+      case SMT_STATUS_SEARCHING:
+      case SMT_STATUS_INTERRUPTED:
       default:
         print_out("BUG: unexpected context status");
         freport_bug(__smt2_globals.err, "BUG: unexpected context status");
@@ -4601,7 +4601,7 @@ static void init_smt2_globals(smt2_globals_t *g) {
 
   g->unsat_core = NULL;
   g->unsat_assumptions = NULL;
-  g->check_with_model_status = STATUS_IDLE;
+  g->check_with_model_status = SMT_STATUS_IDLE;
 
   init_etk_queue(&g->token_queue);
   init_ivector(&g->token_slices, 0);
@@ -6609,9 +6609,9 @@ static yices_thread_result_t YICES_THREAD_ATTR check_delayed_assertions_thread(v
 
 static smt_status_t get_status_from_globals(smt2_globals_t *g) {
   if (g->trivially_unsat) {
-    return STATUS_UNSAT;
+    return SMT_STATUS_UNSAT;
   } else if (g->trivially_sat) {
-    return STATUS_SAT;
+    return SMT_STATUS_SAT;
   } else {
     assert(g->ctx);
     return yices_context_status(g->ctx);

--- a/src/frontend/yices_smt.c
+++ b/src/frontend/yices_smt.c
@@ -1269,9 +1269,9 @@ static void print_results(void) {
   }
   printf("\n\n");
 
-  if (resu == STATUS_SAT) {
+  if (resu == SMT_STATUS_SAT) {
     printf("sat\n");
-  } else if (resu == STATUS_UNSAT) {
+  } else if (resu == SMT_STATUS_UNSAT) {
     printf("unsat\n");
   } else {
     printf("unknown\n");
@@ -2054,7 +2054,7 @@ static int process_benchmark(char *filename) {
 
     print_results();
 
-    if (show_model && (code == STATUS_SAT || code == STATUS_UNKNOWN)) {
+    if (show_model && (code == SMT_STATUS_SAT || code == SMT_STATUS_UNKNOWN)) {
       model = new_model();
       context_build_model(model, &context);
       printf("\nMODEL\n");

--- a/src/frontend/yices_smtcomp.c
+++ b/src/frontend/yices_smtcomp.c
@@ -754,9 +754,9 @@ static void print_results(void) {
   }
 
   resu = context.core->status;
-  if (resu == STATUS_SAT) {
+  if (resu == SMT_STATUS_SAT) {
     printf("sat\n");
-  } else if (resu == STATUS_UNSAT) {
+  } else if (resu == SMT_STATUS_UNSAT) {
     printf("unsat\n");
   } else {
     printf("unknown\n");
@@ -776,9 +776,9 @@ static void print_results(void) {
 
   resu = context.core->status;
 
-  if (resu == STATUS_SAT) {
+  if (resu == SMT_STATUS_SAT) {
     printf("sat\n");
-  } else if (resu == STATUS_UNSAT) {
+  } else if (resu == SMT_STATUS_UNSAT) {
     printf("unsat\n");
   } else {
     printf("unknown\n");
@@ -1305,7 +1305,7 @@ static int process_benchmark(void) {
     }
     print_results();
 
-    if ((simple_model || full_model) && (code == STATUS_SAT || code == STATUS_UNKNOWN)) {
+    if ((simple_model || full_model) && (code == SMT_STATUS_SAT || code == SMT_STATUS_UNKNOWN)) {
       model_t *model;
 
       /*

--- a/src/include/yices.h
+++ b/src/include/yices.h
@@ -2908,28 +2908,28 @@ __YICES_DLLSPEC__ extern int32_t yices_default_config_for_logic(ctx_config_t *co
  *
  *
  * A context can be in one of the following states:
- * 1) STATUS_IDLE: this is the initial state.
+ * 1) SMT_STATUS_IDLE: this is the initial state.
  *    In this state, it's possible to assert formulas.
- *    After assertions, the status may change to STATUS_UNSAT (if
+ *    After assertions, the status may change to SMT_STATUS_UNSAT (if
  *    the assertions are trivially unsatisfiable). Otherwise
- *    the state remains STATUS_IDLE.
+ *    the state remains SMT_STATUS_IDLE.
  *
- * 2) STATUS_SEARCHING: this is the context status during search.
+ * 2) SMT_STATUS_SEARCHING: this is the context status during search.
  *    The context moves into that state after a call to 'check'
  *    and remains in that state until the solver completes
  *    or the search is interrupted.
  *
- * 3) STATUS_SAT/STATUS_UNSAT/STATUS_UNKNOWN: status returned after a search
- *    - STATUS_UNSAT means the assertions are not satisfiable.
- *    - STATUS_SAT means they are satisfiable.
- *    - STATUS_UNKNOWN means that the solver could not determine whether
+ * 3) SMT_STATUS_SAT/SMT_STATUS_UNSAT/SMT_STATUS_UNKNOWN: status returned after a search
+ *    - SMT_STATUS_UNSAT means the assertions are not satisfiable.
+ *    - SMT_STATUS_SAT means they are satisfiable.
+ *    - SMT_STATUS_UNKNOWN means that the solver could not determine whether
  *      the assertions are satisfiable or not. This may happen if
  *      Yices is not complete for the specific logic used (e.g.,
  *      if the formula includes quantifiers).
  *
- * 4) STATUS_INTERRUPTED: if the context is in the STATUS_SEARCHING state,
+ * 4) SMT_STATUS_INTERRUPTED: if the context is in the SMT_STATUS_SEARCHING state,
  *    then it can be interrupted via a call to stop_search.
- *    The status STATUS_INTERRUPTED indicates that.
+ *    The status SMT_STATUS_INTERRUPTED indicates that.
  *
  * For fine tuning: there are options that determine which internal
  * simplifications are applied when formulas are asserted, and
@@ -2969,12 +2969,12 @@ __YICES_DLLSPEC__ extern void yices_free_context(context_t *ctx);
  * - return one of the codes defined in yices_types.h,
  *   namely one of the constants
  *
- *    STATUS_IDLE
- *    STATUS_SEARCHING
- *    STATUS_UNKNOWN
- *    STATUS_SAT
- *    STATUS_UNSAT
- *    STATUS_INTERRUPTED
+ *    SMT_STATUS_IDLE
+ *    SMT_STATUS_SEARCHING
+ *    SMT_STATUS_UNKNOWN
+ *    SMT_STATUS_SAT
+ *    SMT_STATUS_UNSAT
+ *    SMT_STATUS_INTERRUPTED
  *
  */
 __YICES_DLLSPEC__ extern smt_status_t yices_context_status(context_t *ctx);
@@ -2982,7 +2982,7 @@ __YICES_DLLSPEC__ extern smt_status_t yices_context_status(context_t *ctx);
 
 /*
  * Reset: remove all assertions and restore ctx's
- * status to STATUS_IDLE.
+ * status to SMT_STATUS_IDLE.
  */
 __YICES_DLLSPEC__ extern void yices_reset_context(context_t *ctx);
 
@@ -2995,7 +2995,7 @@ __YICES_DLLSPEC__ extern void yices_reset_context(context_t *ctx);
  * Error report:
  * - if the context is not configured to support push/pop
  *   code = CTX_OPERATION_NOT_SUPPORTED
- * - if the context status is STATUS_UNSAT or STATUS_SEARCHING or STATUS_INTERRUPTED
+ * - if the context status is SMT_STATUS_UNSAT or SMT_STATUS_SEARCHING or SMT_STATUS_INTERRUPTED
  *   code = CTX_INVALID_OPERATION
  */
 __YICES_DLLSPEC__ extern int32_t yices_push(context_t *ctx);
@@ -3010,7 +3010,7 @@ __YICES_DLLSPEC__ extern int32_t yices_push(context_t *ctx);
  * - if the context is not configured to support push/pop
  *   code = CTX_OPERATION_NOT_SUPPORTED
  * - if there's no matching push (i.e., the context stack is empty)
- *   or if the context's status is STATUS_SEARCHING
+ *   or if the context's status is SMT_STATUS_SEARCHING
  *   code = CTX_INVALID_OPERATION
  */
 __YICES_DLLSPEC__ extern int32_t yices_pop(context_t *ctx);
@@ -3068,15 +3068,15 @@ __YICES_DLLSPEC__ extern int32_t yices_context_disable_option(context_t *ctx, co
 
 /*
  * Assert formula t in ctx
- * - ctx status must be STATUS_IDLE or STATUS_UNSAT or STATUS_SAT or STATUS_UNKNOWN
+ * - ctx status must be SMT_STATUS_IDLE or SMT_STATUS_UNSAT or SMT_STATUS_SAT or SMT_STATUS_UNKNOWN
  * - t must be a boolean term
  *
- * If ctx's status is STATUS_UNSAT, nothing is done.
+ * If ctx's status is SMT_STATUS_UNSAT, nothing is done.
  *
- * If ctx's status is STATUS_IDLE, STATUS_SAT, or STATUS_UNKNOWN, then
+ * If ctx's status is SMT_STATUS_IDLE, SMT_STATUS_SAT, or SMT_STATUS_UNKNOWN, then
  * the formula is simplified and  asserted in the context. The context
- * status is changed  to STATUS_UNSAT if the formula  is simplified to
- * 'false' or to STATUS_IDLE otherwise.
+ * status is changed  to SMT_STATUS_UNSAT if the formula  is simplified to
+ * 'false' or to SMT_STATUS_IDLE otherwise.
  *
  * This returns 0 if there's no error or -1 if there's an error.
  *
@@ -3088,9 +3088,9 @@ __YICES_DLLSPEC__ extern int32_t yices_context_disable_option(context_t *ctx, co
  *   code = TYPE_MISMATCH
  *   term1 = t
  *   type1 = bool (expected type)
- * if ctx's status is not STATUS_IDLE or STATUS_UNSAT or STATUS_SAT or STATUS_UNKNOWN
+ * if ctx's status is not SMT_STATUS_IDLE or SMT_STATUS_UNSAT or SMT_STATUS_SAT or SMT_STATUS_UNKNOWN
  *   code = CTX_INVALID_OPERATION
- * if ctx's status is neither STATUS_IDLE nor STATUS_UNSAT, and the context is
+ * if ctx's status is neither SMT_STATUS_IDLE nor SMT_STATUS_UNSAT, and the context is
  * not configured for multiple checks
  *   code = CTX_OPERATION_NOT_SUPPORTED
  *
@@ -3102,7 +3102,7 @@ __YICES_DLLSPEC__ extern int32_t yices_assert_formula(context_t *ctx, term_t t);
 
 /*
  * Assert an array of n formulas t[0 ... n-1]
- * - ctx's status must be STATUS_IDLE or STATUS_UNSAT or STATUS_SAT or STATUS_UNKNOWN
+ * - ctx's status must be SMT_STATUS_IDLE or SMT_STATUS_UNSAT or SMT_STATUS_SAT or SMT_STATUS_UNKNOWN
  * - all t[i]'s must be valid boolean terms.
  *
  * The function returns -1 on error, 0 otherwise.
@@ -3125,27 +3125,27 @@ __YICES_DLLSPEC__ extern int32_t yices_assert_formulas(context_t *ctx, uint32_t 
  *
  * The behavior and returned value depend on ctx's current status.
  *
- * 1) If ctx's status is STATUS_SAT, STATUS_UNSAT, or STATUS_UNKNOWN, the function
+ * 1) If ctx's status is SMT_STATUS_SAT, SMT_STATUS_UNSAT, or SMT_STATUS_UNKNOWN, the function
  *    does nothing and just returns the status.
  *
- * 2) If ctx's status is STATUS_IDLE, then the solver searches for a
+ * 2) If ctx's status is SMT_STATUS_IDLE, then the solver searches for a
  *    satisfying assignment. If param != NULL, the search parameters
  *    defined by params are used.
  *
  *    The function returns one of the following codes:
- *    - STATUS_SAT: the context is satisfiable
- *    - STATUS_UNSAT: the context is not satisfiable
- *    - STATUS_UNKNOWN: satisfiability can't be proved or disproved
- *    - STATUS_INTERRUPTED: the search was interrupted
+ *    - SMT_STATUS_SAT: the context is satisfiable
+ *    - SMT_STATUS_UNSAT: the context is not satisfiable
+ *    - SMT_STATUS_UNKNOWN: satisfiability can't be proved or disproved
+ *    - SMT_STATUS_INTERRUPTED: the search was interrupted
  *
  *    The returned status is also stored as the new ctx's status flag,
  *    with the following exception. If the context was built with
  *    mode = INTERACTIVE and the search was interrupted, then the
- *    function returns STATUS_INTERRUPTED but the ctx's state is restored to
+ *    function returns SMT_STATUS_INTERRUPTED but the ctx's state is restored to
  *    what it was before the call to 'yices_check_context' and the
- *    status flag is reset to STATUS_IDLE.
+ *    status flag is reset to SMT_STATUS_IDLE.
  *
- * 3) Otherwise, the function does nothing and returns 'STATUS_ERROR',
+ * 3) Otherwise, the function does nothing and returns 'SMT_STATUS_ERROR',
  *    it also sets the yices error report (code = CTX_INVALID_OPERATION).
  */
 __YICES_DLLSPEC__ extern smt_status_t yices_check_context(context_t *ctx, const param_t *params);
@@ -3164,7 +3164,7 @@ __YICES_DLLSPEC__ extern smt_status_t yices_check_context(context_t *ctx, const 
  * - the assumptions t[0] ... t[n-1] must all be valid Boolean terms
  *
  * This function behaves the same as the previous function.
- * If it returns STATUS_UNSAT, then one can construct an unsat core by
+ * If it returns SMT_STATUS_UNSAT, then one can construct an unsat core by
  * calling function yices_get_unsat_core. The unsat core is a subset of t[0] ... t[n-1]
  * that's inconsistent with ctx.
  */
@@ -3192,7 +3192,7 @@ __YICES_DLLSPEC__ extern smt_status_t yices_check_context_with_assumptions(conte
  *
  * NOTE: if t[i] does not have a value in mdl, then a default value is picked for v_i.
  *
- * If this function returns STATUS_UNSAT and the context supports
+ * If this function returns SMT_STATUS_UNSAT and the context supports
  * model interpolation, then one can construct a model interpolant by
  * calling function yices_get_model_interpolant.
  *
@@ -3204,7 +3204,7 @@ __YICES_DLLSPEC__ extern smt_status_t yices_check_context_with_assumptions(conte
  * If the context does not have the MCSAT solver enabled
  *   code = CTX_OPERATION_NOT_SUPPORTED
  *
- * If the resulting status is STATUS_SAT and context does not support multichecks
+ * If the resulting status is SMT_STATUS_SAT and context does not support multichecks
  *   code = CTX_OPERATION_NOT_SUPPORTED
  *
  *
@@ -3234,13 +3234,13 @@ __YICES_DLLSPEC__ extern smt_status_t yices_check_context_with_model(context_t *
  * - ctx->ctx_A must be a context initialized with support for MCSAT and interpolation.
  * - ctx->ctx_B can be another context (not necessarily with MCSAT support)
  *
- * If this function returns STATUS_UNSAT, then an interpolant is returned in ctx->interpolant.
+ * If this function returns SMT_STATUS_UNSAT, then an interpolant is returned in ctx->interpolant.
  *
- * If this function returns STATUS_SAT and build_model is true, then
+ * If this function returns SMT_STATUS_SAT and build_model is true, then
  * a model is returned in ctx->model. This model must be freed when no-longer needed by
  * calling yices_free_model.
  *
- * If something is wrong, the function returns STATUS_ERROR and sets the yices error report
+ * If something is wrong, the function returns SMT_STATUS_ERROR and sets the yices error report
  * (code = CTX_INVALID_OPERATION).
  *
  * Since 2.6.4.
@@ -3250,18 +3250,18 @@ __YICES_DLLSPEC__ extern smt_status_t yices_check_context_with_interpolation(int
 /*
  * Add a blocking clause: this is intended to help enumerate different models
  * for a set of assertions.
- * - if ctx's status is STATUS_SAT or STATUS_UNKNOWN, then a new clause is added to ctx
+ * - if ctx's status is SMT_STATUS_SAT or SMT_STATUS_UNKNOWN, then a new clause is added to ctx
  *   to remove the current truth assignment from the search space. After this
  *   clause is added, the next call to yices_check_context will either produce
- *   a different truth assignment (hence a different model) or return STATUS_UNSAT.
+ *   a different truth assignment (hence a different model) or return SMT_STATUS_UNSAT.
  *
- * - ctx's status flag is updated to STATUS_IDLE (if the new clause is not empty) or
- *   to STATUS_UNSAT (if the new clause is the empty clause).
+ * - ctx's status flag is updated to SMT_STATUS_IDLE (if the new clause is not empty) or
+ *   to SMT_STATUS_UNSAT (if the new clause is the empty clause).
  *
  * Return code: 0 if there's no error, -1 if there's an error.
  *
  * Error report:
- * if ctx's status is different from STATUS_SAT or STATUS_UNKNOWN
+ * if ctx's status is different from SMT_STATUS_SAT or SMT_STATUS_UNKNOWN
  *    code = CTX_INVALID_OPERATION
  * if ctx is not configured to support multiple checks
  *    code = CTX_OPERATION_NOT_SUPPORTED
@@ -3274,7 +3274,7 @@ __YICES_DLLSPEC__ extern int32_t yices_assert_blocking_clause(context_t *ctx);
  * - this can be called from a signal handler to stop the search,
  *   after a call to yices_check_context to interrupt the solver.
  *
- * If ctx's status is STATUS_SEARCHING, then the current search is
+ * If ctx's status is SMT_STATUS_SEARCHING, then the current search is
  * interrupted. Otherwise, the function does nothing.
  */
 __YICES_DLLSPEC__ extern void yices_stop_search(context_t *ctx);
@@ -3354,13 +3354,13 @@ __YICES_DLLSPEC__ extern void yices_free_param_record(param_t *param);
  * and returns 0. Otherwise, it sets an error core an returns -1.
  *
  * This is intended to be used after a call to
- * yices_check_context_with_assumptions that returned STATUS_UNSAT. In
+ * yices_check_context_with_assumptions that returned SMT_STATUS_UNSAT. In
  * this case, the function builds an unsat core, which is a subset of
  * the assumptions. If there were no assumptions or if the context is UNSAT
  * for another reason, an empty core is returned (i.e., v->size is set to 0).
  *
  * Error code:
- * - CTX_INVALID_OPERATION if the context's status is not STATUS_UNSAT.
+ * - CTX_INVALID_OPERATION if the context's status is not SMT_STATUS_UNSAT.
  */
 __YICES_DLLSPEC__ extern int32_t yices_get_unsat_core(context_t *ctx, term_vector_t *v);
 
@@ -3373,14 +3373,14 @@ __YICES_DLLSPEC__ extern int32_t yices_get_unsat_core(context_t *ctx, term_vecto
  * Otherwise, it sets an error code and return NULL_TERM.
  *
  * This is intended to be used after a call to
- * yices_check_context_with_model that returned STATUS_UNSAT. In this
+ * yices_check_context_with_model that returned SMT_STATUS_UNSAT. In this
  * case, the function builds an model interpolant. The model
  * interpolant is a clause implied by the current context that is
  * false in the model provides to yices_check_context_with_model.
  *
  * Error code:
  * - CTX_OPERATION_NOT_SUPPORTED if the context is not configured with model interpolation
- * - CTX_INVALID_OPERATION if the context's status is not STATUS_UNSAT.
+ * - CTX_INVALID_OPERATION if the context's status is not SMT_STATUS_UNSAT.
  *
  * Since 2.6.4.
  */
@@ -3398,9 +3398,9 @@ __YICES_DLLSPEC__ extern term_t yices_get_model_interpolant(context_t *ctx);
  *   the uninterpreted terms that have been eliminated by simplification:
  *   keep_subst = 0 means don't keep substitutions,
  *   keep_subst != 0 means keep them
- * - ctx status must be STATUS_SAT or STATUS_UNKNOWN
+ * - ctx status must be SMT_STATUS_SAT or SMT_STATUS_UNKNOWN
  *
- * The function returns NULL if the status isn't SAT or STATUS_UNKNOWN
+ * The function returns NULL if the status isn't SAT or SMT_STATUS_UNKNOWN
  * and sets an error report (code = CTX_INVALID_OPERATION).
  *
  * When assertions are added to the context, the simplifications may
@@ -3415,7 +3415,7 @@ __YICES_DLLSPEC__ extern term_t yices_get_model_interpolant(context_t *ctx);
  *    (bg-gt z 0b000)
  *
  * uninterpreted term 'x' gets eliminated. Then a call to 'check_context' will
- * return STATUS_SAT and we can ask for a model 'M'
+ * return SMT_STATUS_SAT and we can ask for a model 'M'
  * - if 'keep_subst' is false then the value of 'x' in 'M' is unavailable.
  * - if 'keep_subst' is true then the value of 'x' in 'M' is computed,
  *   based on the value of 'y' and 'z' in 'M'.
@@ -3607,9 +3607,9 @@ __YICES_DLLSPEC__ extern void yices_model_collect_defined_terms(model_t *mdl, te
  * asserts f in this context and checks whether the context is satisfiable.
  *
  * The return value is
- *   STATUS_SAT if f is satisfiable,
- *   STATUS_UNSAT if f is not satisifiable
- *   STATUS_ERROR if something goes wrong
+ *   SMT_STATUS_SAT if f is satisfiable,
+ *   SMT_STATUS_UNSAT if f is not satisifiable
+ *   SMT_STATUS_ERROR if something goes wrong
  *
  * If the formula is satisfiable and model != NULL, then a model of f is returned in *model.
  * That model must be deleted when no-longer needed by calling yices_free_model.
@@ -3625,7 +3625,7 @@ __YICES_DLLSPEC__ extern void yices_model_collect_defined_terms(model_t *mdl, te
  * If delegate is NULL, the default SAT solver is used.
  *
  * Support for "cadical" and "cryptominisat" must be enabled at compilation
- * time. The "y2sat" solver is always available. The function will return STATUS_ERROR
+ * time. The "y2sat" solver is always available. The function will return SMT_STATUS_ERROR
  * and store an error code if the requested delegate is not available.
  *
  * Error codes:
@@ -3701,7 +3701,7 @@ __YICES_DLLSPEC__ extern int32_t yices_has_delegate(const char *delegate);
  *
  * The bit-vector solver applies various simplifications and preprocessing that may detect
  * that f is SAT or UNSAT without generating a CNF. In this case, the function does not
- * produce a DIMACS file and the formula status (either STATUS_SAT or STATUS_UNSAT) is
+ * produce a DIMACS file and the formula status (either SMT_STATUS_SAT or SMT_STATUS_UNSAT) is
  * returned in variable *status.
  *
  * If simplify_cnf is non-zero, it is also possible for CNF simplification to detect

--- a/src/include/yices_types.h
+++ b/src/include/yices_types.h
@@ -75,13 +75,13 @@ typedef struct param_s param_t;
  * Context status code
  */
 typedef enum smt_status {
-  STATUS_IDLE,
-  STATUS_SEARCHING,
-  STATUS_UNKNOWN,
-  STATUS_SAT,
-  STATUS_UNSAT,
-  STATUS_INTERRUPTED,
-  STATUS_ERROR
+  SMT_STATUS_IDLE,
+  SMT_STATUS_SEARCHING,
+  SMT_STATUS_UNKNOWN,
+  SMT_STATUS_SAT,
+  SMT_STATUS_UNSAT,
+  SMT_STATUS_INTERRUPTED,
+  SMT_STATUS_ERROR
 } smt_status_t;
 
 

--- a/src/mcsat/bv/bv_explainer.c
+++ b/src/mcsat/bv/bv_explainer.c
@@ -177,7 +177,7 @@ void bv_explainer_check_conflict(bv_explainer_t* exp, const ivector_t* conflict)
   }
   smt_status_t result = yices_check_context(ctx, NULL);
   (void) result;
-  assert(result == STATUS_UNSAT);
+  assert(result == SMT_STATUS_UNSAT);
   _o_yices_free_context(ctx);
 }
 

--- a/src/mcsat/bv/bv_utils.h
+++ b/src/mcsat/bv/bv_utils.h
@@ -471,7 +471,7 @@ bool check_rewrite(plugin_context_t* ctx, term_t old, term_t t){
   context_t* yctx      = _o_yices_new_context(NULL);
   _o_yices_assert_formula(yctx, mk_neq(tm, old, t));
   smt_status_t output = yices_check_context(yctx, NULL);
-  bool result = (output == STATUS_UNSAT);
+  bool result = (output == SMT_STATUS_UNSAT);
   if (!result && ctx_trace_enabled(ctx, "mcsat::bv::arith::ctz")) {
     FILE* out = ctx_trace_out(ctx);
     fprintf(out, "Original term is");

--- a/src/mcsat/bv/explain/full_bv_sat.c
+++ b/src/mcsat/bv/explain/full_bv_sat.c
@@ -278,7 +278,7 @@ void bb_sat_solver_solve_and_get_core(bb_sat_solver_t* solver, term_vector_t* co
   // Check the assumptions (should be unsat)
   smt_status_t status = _o_yices_check_context_with_assumptions(solver->yices_ctx, NULL, assumptions.size, assumptions.data);
   (void) status;
-  assert(status == STATUS_UNSAT);
+  assert(status == SMT_STATUS_UNSAT);
 
   // Get the unsat core
   int32_t ret = yices_get_unsat_core(solver->yices_ctx, core);

--- a/src/mcsat/conflict.c
+++ b/src/mcsat/conflict.c
@@ -52,7 +52,7 @@ void conflict_check(conflict_t* conflict) {
   }
   smt_status_t result = yices_check_context(ctx, NULL);
   (void) result;
-  assert(result == STATUS_UNSAT);
+  assert(result == SMT_STATUS_UNSAT);
   _o_yices_free_context(ctx);
   yices_free_config(config);
 }

--- a/src/mcsat/no_mcsat.c
+++ b/src/mcsat/no_mcsat.c
@@ -35,7 +35,7 @@ void mcsat_destruct(mcsat_solver_t *mcsat) {
 }
 
 smt_status_t mcsat_status(const mcsat_solver_t *mcsat) {
-  return STATUS_ERROR;
+  return SMT_STATUS_ERROR;
 }
 
 void mcsat_reset(mcsat_solver_t *mcsat) {

--- a/src/solvers/cdcl/delegate.c
+++ b/src/solvers/cdcl/delegate.c
@@ -73,18 +73,18 @@ static void ysat_add_clause(void *solver, uint32_t n, literal_t *a) {
 static smt_status_t ysat_check(void *solver) {
   // use new sat solver
   switch (nsat_solve(solver)) {
-  case STAT_SAT: return STATUS_SAT;
-  case STAT_UNSAT: return STATUS_UNSAT;
-  default: return STATUS_UNKNOWN;
+  case STAT_SAT: return SMT_STATUS_SAT;
+  case STAT_UNSAT: return SMT_STATUS_UNSAT;
+  default: return SMT_STATUS_UNKNOWN;
   }
 }
 
 static smt_status_t ysat_preprocess(void *solver) {
   // use new sat solver
   switch (nsat_apply_preprocessing(solver)) {
-  case STAT_SAT: return STATUS_SAT;
-  case STAT_UNSAT: return STATUS_UNSAT;
-  default: return STATUS_UNKNOWN;
+  case STAT_SAT: return SMT_STATUS_SAT;
+  case STAT_UNSAT: return SMT_STATUS_UNSAT;
+  default: return SMT_STATUS_UNKNOWN;
   }
 }
 
@@ -218,9 +218,9 @@ static void cadical_add_clause(void *solver, uint32_t n, literal_t *a) {
 
 static smt_status_t cadical_check(void *solver) {
   switch (ccadical_sat(solver)) {
-  case 10: return STATUS_SAT;
-  case 20: return STATUS_UNSAT;
-  default: return STATUS_UNKNOWN;
+  case 10: return SMT_STATUS_SAT;
+  case 20: return SMT_STATUS_UNSAT;
+  default: return SMT_STATUS_UNKNOWN;
   }
 }
 
@@ -344,9 +344,9 @@ static void cryptominisat_add_clause(void *solver, uint32_t n, literal_t *a) {
 
 static smt_status_t cryptominisat_check(void *solver) {
   switch (cmsat_solve(solver)) {
-  case CMSAT_SAT: return STATUS_SAT;
-  case CMSAT_UNSAT: return STATUS_UNSAT;
-  default: return STATUS_UNKNOWN;
+  case CMSAT_SAT: return SMT_STATUS_SAT;
+  case CMSAT_UNSAT: return SMT_STATUS_UNSAT;
+  default: return SMT_STATUS_UNKNOWN;
   }
 }
 
@@ -435,9 +435,9 @@ static void kissat_add_clause(void *solver, uint32_t n, literal_t *a) {
 
 static smt_status_t kissat_check(void *solver) {
   switch (kissat_solve(solver)) {
-  case 10: return STATUS_SAT;
-  case 20: return STATUS_UNSAT;
-  default: return STATUS_UNKNOWN;
+  case 10: return SMT_STATUS_SAT;
+  case 20: return SMT_STATUS_UNSAT;
+  default: return SMT_STATUS_UNKNOWN;
   }
 }
 
@@ -832,7 +832,7 @@ smt_status_t solve_with_delegate(delegate_t *d, smt_core_t *core) {
  * Copy all the clauses of core to delegate d then call the delegate's preprocessor
  */
 smt_status_t preprocess_with_delegate(delegate_t *d, smt_core_t *core) {
-  if (d->preprocess == NULL) return STATUS_UNKNOWN; // not supported
+  if (d->preprocess == NULL) return SMT_STATUS_UNKNOWN; // not supported
 
   copy_problem_clauses(d, core);
   if (d->keep_var != NULL) {

--- a/src/solvers/cdcl/delegate.h
+++ b/src/solvers/cdcl/delegate.h
@@ -127,16 +127,16 @@ extern void delete_delegate(delegate_t *delegate);
 /*
  * Export the clauses from core to the delegate
  * then check satsfiability:
- * - return STATUS_SAT/STATUS_UNSAT if that works
- * - return STATUS_UNKNOWN if the delegate fails
+ * - return SMT_STATUS_SAT/SMT_STATUS_UNSAT if that works
+ * - return SMT_STATUS_UNKNOWN if the delegate fails
  */
 extern smt_status_t solve_with_delegate(delegate_t *delegate, smt_core_t *core);
 
 /*
  * Export the clauses from the core to the delegate
  * then appply delegate's CNF-level preprocessing
- * - return STATUS_SAT/STATUS_UNSAT if that solves the problem
- * - return STATUS_UNKNOWN otherwise (or if the delegate does not support this)
+ * - return SMT_STATUS_SAT/SMT_STATUS_UNSAT if that solves the problem
+ * - return SMT_STATUS_UNKNOWN otherwise (or if the delegate does not support this)
  */
 extern smt_status_t preprocess_with_delegate(delegate_t *delegate, smt_core_t *core);
 

--- a/src/solvers/cdcl/smt_core.h
+++ b/src/solvers/cdcl/smt_core.h
@@ -825,17 +825,17 @@ typedef struct dpll_stats_s {
 #if 0
 // this type is now imported from yices_types.h
 typedef enum smt_status {
-  STATUS_IDLE,
-  STATUS_SEARCHING,
-  STATUS_UNKNOWN,
-  STATUS_SAT,
-  STATUS_UNSAT,
-  STATUS_INTERRUPTED,
-  STATUS_ERROR, // not used by the context operations/only by yices_api
+  SMT_STATUS_IDLE,
+  SMT_STATUS_SEARCHING,
+  SMT_STATUS_UNKNOWN,
+  SMT_STATUS_SAT,
+  SMT_STATUS_UNSAT,
+  SMT_STATUS_INTERRUPTED,
+  SMT_STATUS_ERROR, // not used by the context operations/only by yices_api
 } smt_status_t;
 #endif
 
-#define NUM_SMT_STATUSES (STATUS_ERROR+1)
+#define NUM_SMT_STATUSES (SMT_STATUS_ERROR+1)
 
 /*
  * Optional features: stored as bits in the solver option_flag
@@ -1620,8 +1620,8 @@ extern bool smt_easy_sat(smt_core_t *s);
  * Special forms are provided for unit, binary, and ternary clauses (also
  * for the empty clause).
  *
- * Clauses can be added before the search, when s->status is STATUS_IDLE
- * or on-the-fly, when s->status is STATUS_SEARCHING.
+ * Clauses can be added before the search, when s->status is SMT_STATUS_IDLE
+ * or on-the-fly, when s->status is SMT_STATUS_SEARCHING.
  *
  * If s->status is SEARCHING and s->decision_level > s->base_level,
  * then the clause is a not added immediately, it's copied into the
@@ -1890,13 +1890,13 @@ extern void record_ternary_theory_conflict(smt_core_t *s, literal_t l1, literal_
  * Close the search: mark s as either SAT or UNKNOWN
  */
 static inline void end_search_sat(smt_core_t *s) {
-  assert(s->status == STATUS_SEARCHING || s->status == STATUS_INTERRUPTED);
-  s->status = STATUS_SAT;
+  assert(s->status == SMT_STATUS_SEARCHING || s->status == SMT_STATUS_INTERRUPTED);
+  s->status = SMT_STATUS_SAT;
 }
 
 static inline void end_search_unknown(smt_core_t *s) {
-  assert(s->status == STATUS_SEARCHING || s->status == STATUS_INTERRUPTED);
-  s->status = STATUS_UNKNOWN;
+  assert(s->status == SMT_STATUS_SEARCHING || s->status == SMT_STATUS_INTERRUPTED);
+  s->status = SMT_STATUS_UNKNOWN;
 }
 
 
@@ -1914,7 +1914,7 @@ extern void smt_cleanup(smt_core_t *s);
 /*
  * Clear assignment and enable addition of new clauses after a search.
  * - this can be called if s->status is UNKNOWN or SAT
- * - s->status is reset to STATUS_IDLE and the current boolean
+ * - s->status is reset to SMT_STATUS_IDLE and the current boolean
  *   assignment is cleared (i.e., we backtrack to the current base_level)
  */
 extern void smt_clear(smt_core_t *s);
@@ -1924,15 +1924,15 @@ extern void smt_clear(smt_core_t *s);
  * Cleanup after the search returned unsat
  * - s->status must be UNSAT.
  * - if there are assumptions, this removes them and reset s->status
- *   to STATUS_IDLE
+ *   to SMT_STATUS_IDLE
  * - if clean_interrupt is enabled, this also restores s to its state
  *   before the search: learned clauses are deleted, lemmas, variables
  *   and atoms created during the search are deleted.
  * - if clean_interrupt is disabled and there are no assumptions,
  *   this does nothing.
  *
- * On exit, s->status is either STATUS_UNSAT (if no assumptions
- * were removed) or STATUS_IDLE (if assumptions were removed).
+ * On exit, s->status is either SMT_STATUS_UNSAT (if no assumptions
+ * were removed) or SMT_STATUS_IDLE (if assumptions were removed).
  */
 extern void smt_clear_unsat(smt_core_t *s);
 

--- a/src/solvers/cdcl/smt_core_printer.c
+++ b/src/solvers/cdcl/smt_core_printer.c
@@ -51,8 +51,8 @@ void print_bval(FILE *f, bval_t b) {
  * Status
  */
 void print_status(FILE *f, smt_status_t s) {
-  if (s > STATUS_INTERRUPTED) {
-    s = STATUS_INTERRUPTED + 1;
+  if (s > SMT_STATUS_INTERRUPTED) {
+    s = SMT_STATUS_INTERRUPTED + 1;
   }
   fputs(status2string[s], f);
 }

--- a/src/solvers/quant/quant_solver.c
+++ b/src/solvers/quant/quant_solver.c
@@ -803,11 +803,11 @@ static void ematch_process_cnstr(quant_solver_t *solver, uint32_t cidx) {
 
       for (i=0; i<n; i++) {
         status = smt_status(solver->core);
-        if (status != STATUS_SEARCHING) {
+        if (status != SMT_STATUS_SEARCHING) {
 #if TRACE
           printf("\nSMT status: %d\n", status);
 #endif
-          assert(status == STATUS_UNSAT);
+          assert(status == SMT_STATUS_UNSAT);
           goto done;
         } else if (ematch_reached_instance_limit(solver)) {
 #if TRACE
@@ -1006,11 +1006,11 @@ static void ematch_process_all_cnstr(quant_solver_t *solver) {
   assert(n == solver->round_instances.size);
   for(i=0; i<n; i++) {
     status = smt_status(solver->core);
-    if (status != STATUS_SEARCHING) {
+    if (status != SMT_STATUS_SEARCHING) {
 #if TRACE
       printf("\nSMT status: %d\n", status);
 #endif
-      assert(status == STATUS_UNSAT);
+      assert(status == SMT_STATUS_UNSAT);
       break;
     }
     ematch_add_quant_cnstr(solver, solver->round_cnstrs.data[i], solver->round_instances.data[i]);

--- a/tests/api/balanced_arith_buffers.c
+++ b/tests/api/balanced_arith_buffers.c
@@ -75,7 +75,7 @@ int main(void) {
     // Check that `r_1 == 0` holds
     yices_assert_formula(ctx, check_zero_r_1);
     smt_status_t stat_1 = yices_check_context(ctx, NULL);
-    assert(stat_1 == STATUS_SAT);
+    assert(stat_1 == SMT_STATUS_SAT);
     // Check that the model for `r_1 == 0` validates `r_0 == 0`
     mdl = yices_get_model(ctx, 1);
     assert(yices_get_bool_value(mdl, check_zero_r_0, &model_val) == 0);
@@ -87,7 +87,7 @@ int main(void) {
     yices_push(ctx);
     yices_assert_formula(ctx, check_zero_r_0);
     smt_status_t stat_2 = yices_check_context(ctx, NULL);
-    assert(stat_2 == STATUS_SAT);
+    assert(stat_2 == SMT_STATUS_SAT);
     // Model check
     mdl = yices_get_model(ctx, 1);
     assert(yices_get_bool_value(mdl, check_zero_r_1, &model_val) == 0);

--- a/tests/api/mcsat_preprocessor.c
+++ b/tests/api/mcsat_preprocessor.c
@@ -30,7 +30,7 @@ int main(void)
 
   term_t check_eq_zero = yices_arith_eq_atom(yices_zero(), yices_add(x, yices_int32(1)));
   yices_assert_formula(ctx, check_eq_zero);
-  assert(yices_check_context(ctx, NULL) == STATUS_SAT);
+  assert(yices_check_context(ctx, NULL) == SMT_STATUS_SAT);
   model_t* mdl = yices_get_model(ctx, 1);
   term_t check_model;
   assert(yices_get_bool_value(mdl, check_eq_zero, &check_model) == 0);

--- a/tests/api/model_eval.c
+++ b/tests/api/model_eval.c
@@ -25,7 +25,7 @@ int main(void)
 
   term_t check_zero_t1 = yices_arith_eq_atom(yices_zero(), r_1);
   yices_assert_formula(ctx, check_zero_t1);
-  assert(yices_check_context(ctx, NULL) == STATUS_SAT);
+  assert(yices_check_context(ctx, NULL) == SMT_STATUS_SAT);
   model_t* mdl = yices_get_model(ctx, 1);
   term_t check_mdl;
   assert(yices_get_bool_value(mdl, check_zero_t1, &check_mdl) == 0);

--- a/tests/api/mpq_aux.c
+++ b/tests/api/mpq_aux.c
@@ -30,7 +30,7 @@ int main(void) {
   val = yices_abs(val);
 
   yices_assert_formula(ctx, yices_arith_eq_atom(val, yices_power(yices_int32(2), 30)));
-  assert(yices_check_context(ctx, NULL) == STATUS_SAT);
+  assert(yices_check_context(ctx, NULL) == SMT_STATUS_SAT);
 
   assert(!yices_error_code());
 

--- a/tests/api/nra_plugin_explain.c
+++ b/tests/api/nra_plugin_explain.c
@@ -14,7 +14,7 @@
  *          yices_arith_leq_atom()
  *          _o_yices_arith_leq_atom()
  *          yices_new_context()
- *          yices_check_context() - STATUS_IDLE branch
+ *          yices_check_context() - SMT_STATUS_IDLE branch
  */
 
 #ifdef NDEBUG
@@ -59,7 +59,7 @@ int main(void) {
 
   term_t f_arr[] = { r_1, one };
   yices_assert_formula(ctx, yices_distinct(2, f_arr));
-  assert(yices_check_context(ctx, NULL) == STATUS_UNSAT);
+  assert(yices_check_context(ctx, NULL) == SMT_STATUS_UNSAT);
   assert(!yices_error_code());
 
   yices_free_context(ctx);

--- a/tests/api/nra_plugin_explain_2.c
+++ b/tests/api/nra_plugin_explain_2.c
@@ -35,7 +35,7 @@ int main(void) {
   term_t check = yices_arith_eq_atom(yices_int32(1), one);
   yices_assert_formula(ctx, check);
   smt_status_t stat = yices_check_context(ctx, NULL);
-  assert(stat == STATUS_SAT);
+  assert(stat == SMT_STATUS_SAT);
   model_t* mdl = yices_get_model(ctx, 1);
   term_t val;
   assert(yices_get_bool_value(mdl, check, &val) == 0);

--- a/tests/api/rationals.c
+++ b/tests/api/rationals.c
@@ -27,7 +27,7 @@ int main(void)
   val = yices_idiv(val, val);
 
   yices_assert_formula(ctx, yices_arith_eq_atom(val, yices_int32(1)));
-  assert(yices_check_context(ctx, NULL) == STATUS_SAT);
+  assert(yices_check_context(ctx, NULL) == SMT_STATUS_SAT);
 
   assert(!yices_error_code());
 

--- a/tests/api/rba_buffer_terms.c
+++ b/tests/api/rba_buffer_terms.c
@@ -27,7 +27,7 @@ int main(void) {
     term_t power_term = yices_power(yices_square(x), 2);
 
     yices_assert_formula(ctx, yices_arith_leq_atom(power_term, x));
-    assert(yices_check_context(ctx, NULL) == STATUS_SAT);
+    assert(yices_check_context(ctx, NULL) == SMT_STATUS_SAT);
     assert(!yices_error_code());
 
     yices_free_context(ctx);

--- a/tests/api/term_utils.c
+++ b/tests/api/term_utils.c
@@ -28,7 +28,7 @@ int main(void) {
     term_t abs_term = yices_abs(ite_term);
 
     yices_assert_formula(ctx, yices_eq(abs_term, one));
-    assert(yices_check_context(ctx, NULL) == STATUS_SAT);
+    assert(yices_check_context(ctx, NULL) == SMT_STATUS_SAT);
     assert(!yices_error_code());
 
     yices_free_context(ctx);

--- a/tests/api/uf_plugin.c
+++ b/tests/api/uf_plugin.c
@@ -52,7 +52,7 @@ int main(void) {
   term_t one = generate_one();
 
   yices_assert_formula(ctx, yices_arith_eq_atom(yices_zero(), one));
-  assert(yices_check_context(ctx, NULL) == STATUS_UNSAT);
+  assert(yices_check_context(ctx, NULL) == SMT_STATUS_UNSAT);
   assert(!yices_error_code());
 
   yices_free_context(ctx);

--- a/tests/unit/sudoku.c
+++ b/tests/unit/sudoku.c
@@ -312,7 +312,7 @@ int main(int argc, char* argv[]) {
 
     status = yices_check_context(ctx, NULL);
 
-    if(status == STATUS_SAT){
+    if(status == SMT_STATUS_SAT){
 
       if(get_solution(ctx, b,  solution)){
 

--- a/tests/unit/test_check_formulas.c
+++ b/tests/unit/test_check_formulas.c
@@ -49,11 +49,11 @@ static void test(const char *delegate) {
       show_formulas(n);
       status = yices_check_formulas(formula, n, "QF_BV", &model, delegate);
       switch (status) {
-      case STATUS_UNSAT:
+      case SMT_STATUS_UNSAT:
 	printf("unsat\n");
 	break;
 
-      case STATUS_SAT:
+      case SMT_STATUS_SAT:
 	printf("sat\n");
 	printf("model:\n  ");
 	yices_pp_model(stdout, model, 100, 120, 2);

--- a/tests/unit/test_core2.c
+++ b/tests/unit/test_core2.c
@@ -158,12 +158,12 @@ static void sat_search(smt_core_t *core, uint32_t conflict_bound, uint32_t reduc
   uint64_t max_conflicts;
   literal_t l;
 
-  assert(smt_status(core) == STATUS_SEARCHING || smt_status(core) == STATUS_INTERRUPTED);
+  assert(smt_status(core) == SMT_STATUS_SEARCHING || smt_status(core) == SMT_STATUS_INTERRUPTED);
 
   max_conflicts = num_conflicts(core) + conflict_bound;
 
   smt_process(core);
-  while (smt_status(core) == STATUS_SEARCHING && num_conflicts(core) <= max_conflicts) {
+  while (smt_status(core) == SMT_STATUS_SEARCHING && num_conflicts(core) <= max_conflicts) {
     // reduce heuristic
     if (num_learned_clauses(core) >= reduce_threshold) {
       reduce_clause_database(core);
@@ -215,7 +215,7 @@ static void sat_solve(smt_core_t *core, core_param_t *params, bool verbose) {
   uint32_t c_threshold, d_threshold; // Picosat-style
   uint32_t n_reductions, reduce_threshold;
 
-  assert(smt_status(core) == STATUS_IDLE);
+  assert(smt_status(core) == SMT_STATUS_IDLE);
 
   if (params == NULL) {
     params = &default_settings;
@@ -241,11 +241,11 @@ static void sat_solve(smt_core_t *core, core_param_t *params, bool verbose) {
     show_progress(core, d_threshold, reduce_threshold, true);
   }
 
-  if (smt_status(core) == STATUS_SEARCHING) {
+  if (smt_status(core) == SMT_STATUS_SEARCHING) {
     // loop
     for (;;) {
       sat_search(core, c_threshold, reduce_threshold);
-      if (smt_status(core) != STATUS_SEARCHING) break;
+      if (smt_status(core) != SMT_STATUS_SEARCHING) break;
 
       smt_restart(core);
 
@@ -281,7 +281,7 @@ static void sat_solve(smt_core_t *core, core_param_t *params, bool verbose) {
  * Check whether the unassignment is good (if result is SAT)
  */
 static void validate_assignment(smt_core_t *core) {
-  if (smt_status(core) == STATUS_SAT) {
+  if (smt_status(core) == SMT_STATUS_SAT) {
     if (all_clauses_true(core)) {
       printf("\nModel looks correct\n");
     } else {
@@ -527,8 +527,8 @@ static const char * const status2string[] = {
 };
 
 static void print_status(FILE *f, smt_status_t s) {
-  if (s > STATUS_INTERRUPTED) {
-    s = STATUS_INTERRUPTED + 1;
+  if (s > SMT_STATUS_INTERRUPTED) {
+    s = SMT_STATUS_INTERRUPTED + 1;
   }
   fputs(status2string[s], f);
 }
@@ -590,7 +590,7 @@ static double search_time;
  * Signal handler: call stop_search
  */
 static void handler(int signum) {
-  if (solver.status == STATUS_SEARCHING) {
+  if (solver.status == SMT_STATUS_SEARCHING) {
     stop_search(&solver);
   }
 }

--- a/tests/unit/test_core3.c
+++ b/tests/unit/test_core3.c
@@ -168,13 +168,13 @@ static void sat_search(smt_core_t *core, uint32_t conflict_bound, uint32_t *redu
   uint32_t r_threshold;
   literal_t l;
 
-  assert(smt_status(core) == STATUS_SEARCHING || smt_status(core) == STATUS_INTERRUPTED);
+  assert(smt_status(core) == SMT_STATUS_SEARCHING || smt_status(core) == SMT_STATUS_INTERRUPTED);
 
   max_conflicts = num_conflicts(core) + conflict_bound;
   r_threshold = *reduce_threshold;
 
   smt_process(core);
-  while (smt_status(core) == STATUS_SEARCHING && num_conflicts(core) <= max_conflicts) {
+  while (smt_status(core) == SMT_STATUS_SEARCHING && num_conflicts(core) <= max_conflicts) {
     // reduce heuristic
     if (num_learned_clauses(core) >= r_threshold) {
       reduce_clause_database(core);
@@ -230,7 +230,7 @@ static void sat_solve(smt_core_t *core, core_param_t *params, bool verbose) {
   uint32_t c_threshold, d_threshold; // Picosat-style
   uint32_t reduce_threshold;
 
-  assert(smt_status(core) == STATUS_IDLE);
+  assert(smt_status(core) == SMT_STATUS_IDLE);
 
   if (params == NULL) {
     params = &default_settings;
@@ -255,11 +255,11 @@ static void sat_solve(smt_core_t *core, core_param_t *params, bool verbose) {
     show_progress(core, d_threshold, reduce_threshold, true);
   }
 
-  if (smt_status(core) == STATUS_SEARCHING) {
+  if (smt_status(core) == SMT_STATUS_SEARCHING) {
     // loop
     for (;;) {
       sat_search(core, c_threshold, &reduce_threshold, params->r_factor);
-      if (smt_status(core) != STATUS_SEARCHING) break;
+      if (smt_status(core) != SMT_STATUS_SEARCHING) break;
 
       smt_restart(core);
 
@@ -293,7 +293,7 @@ static void sat_solve(smt_core_t *core, core_param_t *params, bool verbose) {
  * Check whether the unassignment is good (if result is SAT)
  */
 static void validate_assignment(smt_core_t *core) {
-  if (smt_status(core) == STATUS_SAT) {
+  if (smt_status(core) == SMT_STATUS_SAT) {
     if (all_clauses_true(core)) {
       printf("\nModel looks correct\n");
     } else {
@@ -533,8 +533,8 @@ static const char * const status2string[] = {
 };
 
 static void print_status(FILE *f, smt_status_t s) {
-  if (s > STATUS_INTERRUPTED) {
-    s = STATUS_INTERRUPTED + 1;
+  if (s > SMT_STATUS_INTERRUPTED) {
+    s = SMT_STATUS_INTERRUPTED + 1;
   }
   fputs(status2string[s], f);
 }
@@ -596,7 +596,7 @@ static double search_time;
  * Signal handler: call stop_search
  */
 static void handler(int signum) {
-  if (solver.status == STATUS_SEARCHING) {
+  if (solver.status == SMT_STATUS_SEARCHING) {
     stop_search(&solver);
   }
 }

--- a/tests/unit/test_export_formulas.c
+++ b/tests/unit/test_export_formulas.c
@@ -65,9 +65,9 @@ static void test_export(const char *filename, uint32_t n, const term_t t[], bool
     printf("Produced DIMACS file `%s`\n", filename);
   } else if (code == 0) {
     printf("Solved by preprocessing: no file produced\n");
-    if (status == STATUS_SAT) {
+    if (status == SMT_STATUS_SAT) {
       printf(" formulas are satisfiable\n");
-    } else if (status == STATUS_UNSAT) {
+    } else if (status == SMT_STATUS_UNSAT) {
       printf(" formulas are not satisfiable\n");
     } else {
       printf(" BUG: invalid status\n");

--- a/tests/unit/test_gate_manager.c
+++ b/tests/unit/test_gate_manager.c
@@ -99,13 +99,13 @@ static void quick_solve(smt_core_t *core) {
    * this flag.
    */
   if (core->inconsistent) {
-    core->status = STATUS_UNSAT;
+    core->status = SMT_STATUS_UNSAT;
     return;
   }
 
   start_search(core, 0, NULL);
   smt_process(core);
-  while (smt_status(core) == STATUS_SEARCHING) {
+  while (smt_status(core) == SMT_STATUS_SEARCHING) {
     l = select_unassigned_literal(core);
     if (l == null_literal) {
       end_search_sat(core);
@@ -134,7 +134,7 @@ static void print_assignment(smt_core_t *core) {
   bvar_t x;
   uint32_t n, k;
 
-  assert(smt_status(core) == STATUS_SAT);
+  assert(smt_status(core) == SMT_STATUS_SAT);
   n = num_vars(core);
   k = 0;
   for (x = const_bvar + 1; x<n; x++) {
@@ -157,7 +157,7 @@ static void print_decision_literals(smt_core_t *core) {
   ivector_t v;
   uint32_t i, k, n;
 
-  assert(smt_status(core) == STATUS_SAT);
+  assert(smt_status(core) == SMT_STATUS_SAT);
   init_ivector(&v, 10);
   collect_decision_literals(core, &v);
 
@@ -194,7 +194,7 @@ static void all_sat(smt_core_t *core) {
     //    print_clauses(stdout, core);
 
     quick_solve(core);
-    if (smt_status(core) != STATUS_SAT) break;
+    if (smt_status(core) != SMT_STATUS_SAT) break;
 
     s ++;
     print_assignment(core);

--- a/tests/unit/test_mcsat.c
+++ b/tests/unit/test_mcsat.c
@@ -130,8 +130,8 @@ static void test_mcsat(void) {
   if (code < 0) print_error();
 
   status = yices_check_context(ctx, NULL);
-  if (status != STATUS_SAT) {
-    fprintf(stderr, "Test failed: status != STATUS_SAT\n");
+  if (status != SMT_STATUS_SAT) {
+    fprintf(stderr, "Test failed: status != SMT_STATUS_SAT\n");
     exit(1);
   }
 


### PR DESCRIPTION
Towards fixing #418 

Reason for the change:

STATUS_INTERRUPTED is a defined in windows, and we are using it in the smt_status_t enum. This PR renames the symbols used in the smt_status_t enum.