### PR TITLE
Update ci -- run mcsat with thread-safety

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Build and install libpoly
-      if: inputs.config-opt == '--enable-mcsat'
+      if: contains(inputs.config-opt, '--enable-mcsat')
       shell: bash
       run: |
         pushd .
@@ -26,7 +26,7 @@ runs:
         sudo make install
         popd
     - name: Build and install CUDD
-      if: inputs.config-opt == '--enable-mcsat'
+      if: contains(inputs.config-opt, '--enable-mcsat')
       shell: bash
       run: |
         pushd .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,16 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         mode: [debug, release]
-        config-opt: [--enable-mcsat, --enable-thread-safety --enable-mcsat]
+        config-opt: [--enable-mcsat, --enable-thread-safety]
         env: [CC=gcc CXX=g++, CC=clang CXX=clang++]
         include:
           - os: ubuntu-latest
             mode: gcov
             config-opt: --enable-mcsat
+            env: CC=gcc CXX=g++
+          - os: ubuntu-latest
+            mode: debug
+            config-opt: --enable-thread-safety --enable-mcsat
             env: CC=gcc CXX=g++
 
     name: ${{ matrix.os }}|${{ matrix.mode }}|${{ matrix.config-opt }}|${{ matrix.env }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         mode: [debug, release]
-        config-opt: [--enable-mcsat, --enable-thread-safety]
+        config-opt: [--enable-mcsat, --enable-thread-safety --enable-mcsat]
         env: [CC=gcc CXX=g++, CC=clang CXX=clang++]
         include:
           - os: ubuntu-latest


### PR DESCRIPTION
This PR enables running yices-mcsat with the thread-safety option. 
We run it only with GCC, and not with clang because of the unavailability of thread-local storage.