### PR TITLE
Mcsat set initial var order api

### DIFF
--- a/doc/sphinx/source/context-operations.rst
+++ b/doc/sphinx/source/context-operations.rst
@@ -1218,7 +1218,7 @@ are not affected by the dynamic variable decision heuristic like
 VSIDS. Moreover, a subsequent calls to this operation will overwrite
 previously set ordering.
 
-.. c:function:: smt_status_t yices_mcsat_set_fixed_var_order(context_t *ctx, const term_t t[], uint32_t n)
+.. c:function:: smt_status_t yices_mcsat_set_fixed_var_order(context_t *ctx, uint32_t n, const term_t t[])
 
    Set a fixed variable ordering for the MCSat search.
 
@@ -1252,7 +1252,7 @@ in the beginning of the MCSAT search -- once that order has been
 decided, MCSAT can choose according to its heuristics from that point
 onward. 
 
-.. c:function:: smt_status_t yices_mcsat_set_initial_var_order(context_t *ctx, const term_t t[], uint32_t n)
+.. c:function:: smt_status_t yices_mcsat_set_initial_var_order(context_t *ctx, uint32_t n, const term_t t[])
 
    Set an initial variable ordering for the MCSat search.
 

--- a/doc/sphinx/source/context-operations.rst
+++ b/doc/sphinx/source/context-operations.rst
@@ -1207,10 +1207,10 @@ as follows::
      -- error code: :c:enum:`CTX_INVALID_OPERATION`
 
 
-Set Variable Ordering for MCSat
--------------------------------
+Set a Fixed Variable Ordering for MCSat
+---------------------------------------
 
-It is possible to give a variable ordering for the MCSat search --
+It is possible to give a fixed variable ordering for the MCSat search --
 this will make MCSAT to decide the variables in the given order. Note
 that the variables in the given ordering are always decided earlier
 than the ones not in the ordering. Therefore, the ordering variables
@@ -1218,9 +1218,43 @@ are not affected by the dynamic variable decision heuristic like
 VSIDS. Moreover, a subsequent calls to this operation will overwrite
 previously set ordering.
 
-.. c:function:: smt_status_t yices_mcsat_set_var_order(context_t *ctx, const term_t t[], uint32_t n)
+.. c:function:: smt_status_t yices_mcsat_set_fixed_var_order(context_t *ctx, const term_t t[], uint32_t n)
 
-   Set the variable ordering for the MCSat search.
+   Set a fixed variable ordering for the MCSat search.
+
+   **Parameters**
+
+   - *ctx* is a context
+
+   - *t* is an array of variables
+
+   - *n* is the size of the *t* array
+
+   If the operation fails, it will return :c:enum:`STATUS_ERROR`,
+   otherwise it returns :c:enum:`STATUS_IDLE`.
+
+   **Error report**
+
+   - If the context is not configured for MCSat:
+
+     -- error code: :c:enum:`CTX_OPERATION_NOT_SUPPORTED`
+
+   - If the terms in the *t* array are not variables:
+
+     -- error code: :c:enum:`VARIABLE_REQUIRED`
+
+
+Set a Initial Variable Ordering for MCSat
+-----------------------------------------
+
+It is also possible to give a variable ordering that will be used only
+in the beginning of the MCSAT search -- once that order has been
+decided, MCSAT can choose according to its heuristics from that point
+onward. 
+
+.. c:function:: smt_status_t yices_mcsat_set_initial_var_order(context_t *ctx, const term_t t[], uint32_t n)
+
+   Set an initial variable ordering for the MCSat search.
 
    **Parameters**
 

--- a/src/api/yices_api.c
+++ b/src/api/yices_api.c
@@ -9319,7 +9319,7 @@ EXPORTED smt_status_t yices_check_context_with_model_and_hint(context_t *ctx, co
 }
 
 /*
- * Set variable ordering for making mcsat decisions.
+ * Set a fixed variable ordering for making mcsat decisions.
  *
  * NOTE: This will overwrite the previously set ordering.
  */
@@ -9341,6 +9341,27 @@ EXPORTED smt_status_t yices_mcsat_set_var_order(context_t *ctx, uint32_t n, cons
   return STATUS_IDLE;
 }
 
+/*
+ * Set an initial variable ordering for making mcsat decisions.
+ *
+ */
+EXPORTED smt_status_t yices_mcsat_set_initial_var_order(context_t *ctx, uint32_t n, const term_t t[]) {
+
+  if (! context_has_mcsat(ctx)) {
+    set_error_code(CTX_OPERATION_NOT_SUPPORTED);
+    return STATUS_ERROR;
+  }
+
+  if (! good_terms_for_check_with_model(n, t)) {
+    set_error_code(VARIABLE_REQUIRED);
+    return STATUS_ERROR;
+  }
+
+  ivector_t *order = &ctx->mcsat_initial_var_order;
+  ivector_copy(order, t, n);
+
+  return STATUS_IDLE;
+}
 
 /*
  * CHECK SAT AND COMPUTE INTERPOLANT

--- a/src/api/yices_api.c
+++ b/src/api/yices_api.c
@@ -9323,7 +9323,7 @@ EXPORTED smt_status_t yices_check_context_with_model_and_hint(context_t *ctx, co
  *
  * NOTE: This will overwrite the previously set ordering.
  */
-EXPORTED smt_status_t yices_mcsat_set_var_order(context_t *ctx, uint32_t n, const term_t t[]) {
+EXPORTED smt_status_t yices_mcsat_set_fixed_var_order(context_t *ctx, uint32_t n, const term_t t[]) {
 
   if (! context_has_mcsat(ctx)) {
     set_error_code(CTX_OPERATION_NOT_SUPPORTED);

--- a/src/context/context.c
+++ b/src/context/context.c
@@ -5715,6 +5715,7 @@ void init_context(context_t *ctx, term_table_t *terms, smt_logic_t logic,
   // mcsat options default
   init_mcsat_options(&ctx->mcsat_options);
   init_ivector(&ctx->mcsat_var_order, CTX_DEFAULT_VECTOR_SIZE);
+  init_ivector(&ctx->mcsat_initial_var_order, CTX_DEFAULT_VECTOR_SIZE);
   /*
    * Allocate and initialize the solvers and core
    * NOTE: no theory solver yet if arch is AUTO_IDL or AUTO_RDL
@@ -5774,6 +5775,7 @@ void delete_context(context_t *ctx) {
   delete_gate_manager(&ctx->gate_manager);
   /* delete_mcsat_options(&ctx->mcsat_options); // if used then the same memory is freed twice */
   delete_ivector(&ctx->mcsat_var_order);
+  delete_ivector(&ctx->mcsat_initial_var_order);
 
   delete_intern_tbl(&ctx->intern);
   delete_ivector(&ctx->top_eqs);

--- a/src/context/context_types.h
+++ b/src/context/context_types.h
@@ -727,8 +727,10 @@ struct context_s {
 
   // options for the mcsat solver
   mcsat_options_t mcsat_options;
-  // ordering for forcing mcsat assignment order
+  // fixed ordering for forcing mcsat assignment order
   ivector_t mcsat_var_order;
+  // initial ordering for forcing mcsat assignment order
+  ivector_t mcsat_initial_var_order;
 
   // flag for enabling adding quant instances
   bool en_quant;

--- a/src/include/yices.h
+++ b/src/include/yices.h
@@ -3276,7 +3276,8 @@ __YICES_DLLSPEC__ extern smt_status_t yices_check_context_with_model_and_hint(co
 									      uint32_t m);
 
 /*
- * Set variable ordering for making mcsat decisions.
+ * Set a fixed variable ordering for making mcsat decisions. MCSAT
+ * will always first decide these variables in the given order.
  *
  * - ctx must be a context initialized with support for MCSAT
  *   (see yices_new_context, yices_new_config, yices_set_config).
@@ -3294,6 +3295,26 @@ __YICES_DLLSPEC__ extern smt_status_t yices_check_context_with_model_and_hint(co
 __YICES_DLLSPEC__ extern smt_status_t yices_mcsat_set_var_order(context_t *ctx,
                                                                 uint32_t n,
 								const term_t t[]);
+
+/*
+ * Set initial variable ordering for making mcsat decisions. This is
+ * one-time ordering that is done initially in the MCSAT search.
+ *
+ * - ctx must be a context initialized with support for MCSAT
+ *   (see yices_new_context, yices_new_config, yices_set_config).
+ * - t is an array of n terms
+ *
+ *
+ * Returns STATUS_ERROR if mcsat context is not enabled, otherwise returns STATUS_IDLE
+ *
+ * Error codes:
+ *
+ * If the context does not have the MCSAT solver enabled
+ *   code = CTX_OPERATION_NOT_SUPPORTED
+ */
+__YICES_DLLSPEC__ extern smt_status_t yices_mcsat_set_initial_var_order(context_t *ctx,
+                                                                        uint32_t n,
+                                                                        const term_t t[]);
 
 /*
  * Check satisfiability and compute interpolant.

--- a/src/include/yices.h
+++ b/src/include/yices.h
@@ -3292,9 +3292,9 @@ __YICES_DLLSPEC__ extern smt_status_t yices_check_context_with_model_and_hint(co
  * If the context does not have the MCSAT solver enabled
  *   code = CTX_OPERATION_NOT_SUPPORTED
  */
-__YICES_DLLSPEC__ extern smt_status_t yices_mcsat_set_var_order(context_t *ctx,
-                                                                uint32_t n,
-								const term_t t[]);
+__YICES_DLLSPEC__ extern smt_status_t yices_mcsat_set_fixed_var_order(context_t *ctx,
+                                                                      uint32_t n,
+								      const term_t t[]);
 
 /*
  * Set initial variable ordering for making mcsat decisions. This is

--- a/tests/api/test_mcsat_set_var_order.c
+++ b/tests/api/test_mcsat_set_var_order.c
@@ -35,7 +35,7 @@ int main(void)
   term_t order_vars[2];
   order_vars[0] = y;
   order_vars[1] = x;
-  yices_mcsat_set_var_order(ctx, 2, order_vars);
+  yices_mcsat_set_fixed_var_order(ctx, 2, order_vars);
 
   // model hint
   model_t* mdl = yices_new_model();


### PR DESCRIPTION
Adds a new api method for setting initial variable ordering (MCSAT)

Renames set_variable_order -> set_fixed_variable_order

Adds documentation

