### PR TITLE
print_smt2_model: adjust for SMT-LIB syntax

### DIFF
--- a/src/frontend/smt2/smt2_commands.c
+++ b/src/frontend/smt2/smt2_commands.c
@@ -3972,7 +3972,7 @@ static void print_smt2_model(smt2_pp_t *printer, smt2_model_t *sm) {
   terms = __yices_globals.terms;
   vtbl = model_get_vtbl(sm->model);
 
-  pp_open_block(&printer->pp, PP_OPEN_SMT2_MODEL);
+  pp_open_block(&printer->pp, PP_OPEN_TPAR);
 
   n = sm->names.size;
   for (i=0; i<n; i++) {

--- a/src/io/yices_pp.c
+++ b/src/io/yices_pp.c
@@ -167,6 +167,7 @@ static const pp_nonstandard_block_t nonstandard_block[NUM_NONSTANDARD_BLOCKS] = 
   { PP_OPEN, "", PP_HMT_LAYOUT, 0, 1, 1 },
   { PP_OPEN_PAR, "", PP_HMT_LAYOUT, PP_TOKEN_PAR_MASK, 1, 1 },
   { PP_OPEN_VPAR, "", PP_V_LAYOUT, PP_TOKEN_PAR_MASK, 1, 1 },
+  { PP_OPEN_TPAR, "", PP_T_LAYOUT, PP_TOKEN_PAR_MASK, 1, 1 },
   { PP_OPEN_BV_TYPE, "bitvector", PP_H_LAYOUT, PP_TOKEN_DEF_MASK, 0, 0 },
   { PP_OPEN_FF_TYPE, "finitefield", PP_H_LAYOUT, PP_TOKEN_DEF_MASK, 0, 0 },
   { PP_OPEN_CONST_DEF, "constant", PP_H_LAYOUT, PP_TOKEN_DEF_MASK, 0, 0 },
@@ -180,7 +181,6 @@ static const pp_nonstandard_block_t nonstandard_block[NUM_NONSTANDARD_BLOCKS] = 
   { PP_OPEN_SMT2_BV_TYPE, "_ BitVec", PP_H_LAYOUT, PP_TOKEN_DEF_MASK, 0, 0},
   { PP_OPEN_SMT2_FF_DEC, "_ ff", PP_H_LAYOUT, PP_TOKEN_PAR_MASK, 0, 0 },
   { PP_OPEN_SMT2_FF_TYPE, "_ FiniteField", PP_H_LAYOUT, PP_TOKEN_DEF_MASK, 0, 0},
-  { PP_OPEN_SMT2_MODEL, "model", PP_T_LAYOUT, PP_TOKEN_DEF_MASK, 2, 2 },
   { PP_OPEN_SMT2_DEF, "define-fun", PP_HMT_LAYOUT, PP_TOKEN_DEF_MASK, 2, 2 },
 };
 

--- a/src/io/yices_pp.h
+++ b/src/io/yices_pp.h
@@ -175,6 +175,7 @@ typedef enum {
   PP_OPEN,               // empty label, no parenthesis, HMT layout
   PP_OPEN_PAR,           // empty label, open parenthesis, HMT layout
   PP_OPEN_VPAR,          // empty label, open parenthesis, V layout
+  PP_OPEN_TPAR,          // empty label, open parenthesis, T layout
 
   PP_OPEN_BV_TYPE,
   PP_OPEN_FF_TYPE,
@@ -250,7 +251,6 @@ typedef enum {
   PP_OPEN_SMT2_BV_TYPE, // (_ BitVec ...)
   PP_OPEN_SMT2_FF_DEC, // (_ ff... ..)
   PP_OPEN_SMT2_FF_TYPE, // (_ FiniteField ...)
-  PP_OPEN_SMT2_MODEL,   // (model ...)
   PP_OPEN_SMT2_DEF,     // (define-fun ...)
   PP_OPEN_SMT2_STORE,   // (store <array> <index> <value>)
   PP_OPEN_SMT2_AS_CONST,  // (as const <type> <value>)  (for constant arrays. type is the array type).

--- a/tests/regress/wd/example_mdl.smt2.gold
+++ b/tests/regress/wd/example_mdl.smt2.gold
@@ -1,6 +1,5 @@
 sat
-(model
-  (define-fun arr1 ((x!0 Int)) Bool false)
+((define-fun arr1 ((x!0 Int)) Bool false)
   (define-fun arr2 ((x!0 Int)) Bool (ite (= x!0 10) true false)))
 ((arr1 ((as const (Array Int Bool)) false))
  (arr2 (store ((as const (Array Int Bool)) false) 10 true)))

--- a/tests/regress/wd/example_mdl2.smt2.gold
+++ b/tests/regress/wd/example_mdl2.smt2.gold
@@ -1,6 +1,5 @@
 sat
-(model
-  (define-fun a () (_ BitVec 4) (_ bv5 4)))
+((define-fun a () (_ BitVec 4) (_ bv5 4)))
 ((a (_ bv5 4))
  (b (_ bv5 8))
  (c (_ bv5 80)))


### PR DESCRIPTION
The `model` keyword was adopted by many solvers at some point but was never part of the SMT-LIB standard. Nowadays, most popular solvers stick closely to the standard in this respect and have dropped the `(model ...)` syntax.

More details here:

https://github.com/Z3Prover/z3/issues/4807
https://groups.google.com/g/smt-lib/c/5xpcIxdQ8-A/m/lGGxtApUAgAJ

Thanks! :slightly_smiling_face: 