### PR TITLE
Fix #517: fallback when EF projection sees unsupported arith term

### DIFF
--- a/src/exists_forall/efsolver.c
+++ b/src/exists_forall/efsolver.c
@@ -1063,6 +1063,17 @@ static term_t ef_generalize3(ef_solver_t *solver, term_t cex_cnstr, uint32_t i) 
   code = 0;
   pflag = project_literals(mdl, solver->prob->manager, v->size, v->data, n, cnstr->uvars, w, &code);
 
+  if (pflag == PROJ_ERROR_UNSUPPORTED_ARITH_TERM) {
+    // Keep normal projection behavior, but recover from unsupported terms.
+    result = ef_generalize2(solver->prob, cex_cnstr, i, solver->uvalue_aux.data);
+    if (result < 0) {
+      solver->status = EF_STATUS_SUBST_ERROR;
+      solver->error_code = result;
+      return NULL_TERM;
+    }
+    return result;
+  }
+
   if (pflag != PROJ_NO_ERROR) {
     solver->status = EF_STATUS_PROJECTION_ERROR;
     solver->error_code = pflag;
@@ -1611,5 +1622,3 @@ void ef_solver_check(ef_solver_t *solver, const param_t *parameters,
 
   ef_solver_search(solver);
 }
-
-

--- a/tests/regress/iss517.smt2
+++ b/tests/regress/iss517.smt2
@@ -1,0 +1,4 @@
+(set-logic LIA)
+(declare-fun i0 () Int)
+(assert (forall ((q22 Int)) (or (< q22 (abs i0)) (> q22 (abs i0)))))
+(check-sat)

--- a/tests/regress/iss517.smt2.gold
+++ b/tests/regress/iss517.smt2.gold
@@ -1,0 +1,1 @@
+unknown


### PR DESCRIPTION
Fix #517. The particular execution path was trying to do a projection but hit the abs construct, which it doesn't know how to treat. If that happens we now resort to generalization by substitution (instead of projection), which avoids the "can't handle" error but of course is a poor generalization technique. In the case it leads to "unknown" answer. Probably better than giving up upon seeing abs...