### PR TITLE
Hardened #589 update + added missing API for building tuple and functional values and setting them in model

### DIFF
--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -6,4 +6,4 @@ runs:
     - name: Run Coverage
       shell: bash
       run: |
-        lcov --directory build --base-directory src --capture --output-file coverage.info
+        lcov --directory build --base-directory src --capture --ignore-errors source --output-file coverage.info

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -17,7 +17,6 @@ runs:
 
     - name: Test Yices API
       shell: bash
-      if: inputs.mode != 'gcov'
       run: |
         # This is needed for yices2 to find libpoly.so.0. /usr/local/lib not searched by default?
         export LD_LIBRARY_PATH=/usr/local/lib/:${LD_LIBRARY_PATH}

--- a/doc/sphinx/source/model-operations.rst
+++ b/doc/sphinx/source/model-operations.rst
@@ -750,13 +750,14 @@ These functions are useful for creating custom models or modifying existing ones
 
    - *model*: pointer to the model in which the assignment is made
    - *var*: the uninterpreted symbol to assign a value to
-   - *yval*: the value descriptor (possibly from another model)
+   - *yval*: the value descriptor from the same model
 
    **Requirements**
 
    - *var* must be an uninterpreted term
    - *var* must not already have a value in model
    - *yval* must be compatible with var's type
+   - *yval* **HAS** to come from the same model instance
 
    **Returns**
 
@@ -768,6 +769,163 @@ These functions are useful for creating custom models or modifying existing ones
    - If *var* is not a valid uninterpreted term or is already assigned:
 
      -- error code: :c:enum:`INVALID_TERM`
+
+.. c:function:: int32_t yices_model_make_tuple(model_t *model, uint32_t n, const yval_t elem[], yval_t *tuple)
+
+   Build a tuple value in *model* from an array of value descriptors.
+
+   **Parameters**
+
+   - *model*: pointer to the model in which the tuple is built
+   - *n*: number of tuple elements
+   - *elem*: array of *n* value descriptors
+   - *tuple*: output descriptor for the resulting tuple value
+
+   **Requirements**
+
+   - every descriptor in *elem* must refer to a value in *model*
+   - every descriptor in *elem* must have a tag consistent with the referenced value
+
+   **Returns**
+
+   - 0 on success
+   - -1 on error
+
+   **Error report**
+
+   - If one of the descriptors in *elem* is invalid for *model*:
+
+     -- error code: :c:enum:`TYPE_MISMATCH`
+
+.. c:function:: int32_t yices_model_set_tuple(model_t *model, term_t var, uint32_t n, const yval_t elem[])
+
+   Assign a tuple value built from *elem* to an uninterpreted symbol in *model*.
+
+   **Parameters**
+
+   - *model*: pointer to the model in which the assignment is made
+   - *var*: the uninterpreted symbol to assign a value to
+   - *n*: number of tuple elements
+   - *elem*: array of *n* value descriptors
+
+   **Requirements**
+
+   - *var* must be an uninterpreted term
+   - *var* must not already have a value in model
+   - every descriptor in *elem* must refer to a value in *model*
+   - the tuple built from *elem* must be type-compatible with *var*
+
+   **Returns**
+
+   - 0 on success
+   - -1 on error
+
+   **Error report**
+
+   - If *var* is invalid/already assigned:
+
+     -- error code: :c:enum:`INVALID_TERM`
+   - If one element in *elem* is invalid for *model* or tuple type is incompatible:
+
+     -- error code: :c:enum:`TYPE_MISMATCH`
+
+.. c:function:: int32_t yices_model_make_mapping(model_t *model, uint32_t arity, const yval_t args[], const yval_t *value, yval_t *mapping)
+
+   Build a mapping value [*args[0]* ... *args[arity-1]* -> *value*] in *model*.
+
+   **Parameters**
+
+   - *model*: pointer to the model in which the mapping is built
+   - *arity*: number of mapping arguments
+   - *args*: array of *arity* argument descriptors
+   - *value*: descriptor for the mapping result
+   - *mapping*: output descriptor for the resulting mapping value
+
+   **Requirements**
+
+   - every descriptor in *args* must refer to a value in *model*
+   - *value* must refer to a value in *model*
+   - every descriptor tag must be consistent with the referenced value
+
+   **Returns**
+
+   - 0 on success
+   - -1 on error
+
+   **Error report**
+
+   - If one input descriptor is invalid for *model*:
+
+     -- error code: :c:enum:`TYPE_MISMATCH`
+
+.. c:function:: int32_t yices_model_make_function(model_t *model, type_t fun_type, uint32_t n, const yval_t mappings[], const yval_t *def, yval_t *fun)
+
+   Build a function value in *model* from mapping descriptors and a default value.
+
+   **Parameters**
+
+   - *model*: pointer to the model in which the function is built
+   - *fun_type*: function type of the result
+   - *n*: number of mapping descriptors
+   - *mappings*: array of *n* mapping descriptors
+   - *def*: default value descriptor
+   - *fun*: output descriptor for the resulting function value
+
+   **Requirements**
+
+   - *fun_type* must be a function type
+   - every descriptor in *mappings* must refer to a mapping value in *model*
+   - every descriptor in *mappings* must have a tag consistent with the referenced value
+   - each mapping must have the same arity as *fun_type*'s domain
+   - each mapping argument/result must be type-compatible with *fun_type*
+   - *def* must refer to a value in *model* and be type-compatible with *fun_type*'s range
+
+   **Returns**
+
+   - 0 on success
+   - -1 on error
+
+   **Error report**
+
+   - If *fun_type* is not a function type:
+
+     -- error code: :c:enum:`TYPE_MISMATCH`
+   - If one mapping/default descriptor is invalid for *model* or not type-compatible:
+
+     -- error code: :c:enum:`TYPE_MISMATCH`
+
+.. c:function:: int32_t yices_model_set_function(model_t *model, term_t var, uint32_t n, const yval_t mappings[], const yval_t *def)
+
+   Assign a function value built from *mappings* and *def* to an uninterpreted symbol in *model*.
+
+   **Parameters**
+
+   - *model*: pointer to the model in which the assignment is made
+   - *var*: the uninterpreted symbol to assign a value to
+   - *n*: number of mapping descriptors
+   - *mappings*: array of *n* mapping descriptors
+   - *def*: default value descriptor
+
+   **Requirements**
+
+   - *var* must be an uninterpreted term
+   - *var* must have function type
+   - *var* must not already have a value in model
+   - *mappings*/*def* must satisfy the same requirements as in :c:func:`yices_model_make_function`
+
+   **Returns**
+
+   - 0 on success
+   - -1 on error
+
+   **Error report**
+
+   - If *var* is invalid or already assigned:
+
+     -- error code: :c:enum:`INVALID_TERM`
+   - If *var* does not have function type or *mappings*/*def* are invalid:
+
+     -- error code: :c:enum:`TYPE_MISMATCH`
 
 
 
@@ -1830,4 +1988,3 @@ This parameter takes a value of type :c:type:`yices_gen_mode_t`:
 
    This function is equivalent to calling :c:func:`yices_generalize_model` with
    argument (*a[0]* |and| |...| |and| *a[n-1]*).
-

--- a/doc/sphinx/source/model-operations.rst
+++ b/doc/sphinx/source/model-operations.rst
@@ -927,6 +927,59 @@ These functions are useful for creating custom models or modifying existing ones
 
      -- error code: :c:enum:`TYPE_MISMATCH`
 
+Example (compile/run checked)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following example demonstrates tuple and function value construction
+with ``yval_t`` objects.
+
+.. code-block:: c
+
+   model_t *model = yices_new_model();
+   type_t int_type = yices_int_type();
+   type_t bool_type = yices_bool_type();
+   type_t tuple_type = yices_tuple_type3(int_type, int_type, bool_type);
+   type_t fun_type = yices_function_type2(int_type, int_type, bool_type);
+
+   term_t x = yices_new_uninterpreted_term(int_type);
+   term_t y = yices_new_uninterpreted_term(int_type);
+   term_t b = yices_new_uninterpreted_term(bool_type);
+   term_t t = yices_new_uninterpreted_term(tuple_type);
+   term_t f = yices_new_uninterpreted_term(fun_type);
+
+   yices_model_set_int32(model, x, 3);
+   yices_model_set_int32(model, y, 5);
+   yices_model_set_bool(model, b, 1);
+
+   yval_t xv, yv, bv;
+   yices_get_value(model, x, &xv);
+   yices_get_value(model, y, &yv);
+   yices_get_value(model, b, &bv);
+
+   // Tuple: (x, y, b)
+   yval_t tuple_elems[3] = { xv, yv, bv };
+   yval_t tuple_v;
+   yices_model_make_tuple(model, 3, tuple_elems, &tuple_v);
+   yices_model_set_tuple(model, t, 3, tuple_elems);
+
+   // Mapping: [x, y -> b]
+   yval_t map_args[2] = { xv, yv };
+   yval_t map_v;
+   yices_model_make_mapping(model, 2, map_args, &bv, &map_v);
+
+   // Function with one mapping and default false
+   yval_t false_v;
+   yices_get_value(model, yices_false(), &false_v);
+   yval_t maps[1] = { map_v };
+   yval_t fun_v;
+   yices_model_make_function(model, fun_type, 1, maps, &false_v, &fun_v);
+   yices_model_set_function(model, f, 1, maps, &false_v);
+
+   // Query result for f(x, y)
+   term_t fxy = yices_application2(f, x, y);
+   int32_t bval;
+   yices_get_bool_value(model, fxy, &bval);
+
 
 
 Atomic Values

--- a/src/api/yices_api.c
+++ b/src/api/yices_api.c
@@ -10198,10 +10198,26 @@ static bool check_model_yval(value_table_t *vtbl, const yval_t *yval, value_t *v
   return true;
 }
 
+/*
+ * Check whether value v is compatible with type tau.
+ * - uses the value-table type cache (see vtbl_value_type).
+ */
+static bool check_value_type(value_table_t *vtbl, value_t v, type_t tau) {
+  type_t sigma;
+
+  assert(good_object(vtbl, v));
+  assert(good_type(vtbl->type_table, tau));
+
+  sigma = vtbl_value_type(vtbl, v);
+  if (sigma == NULL_TYPE) {
+    return false;
+  }
+  return is_subtype(vtbl->type_table, sigma, tau);
+}
+
 int32_t _o_yices_model_set_yval(model_t *model, term_t var, const yval_t *yval) {
   value_table_t *vtbl;
   value_t v;
-  term_t value_term;
   type_t tau;
   
   if (! check_good_term(__yices_globals.manager, var) ||
@@ -10216,9 +10232,7 @@ int32_t _o_yices_model_set_yval(model_t *model, term_t var, const yval_t *yval) 
   }
 
   tau = term_type(__yices_globals.terms, var);
-  value_term = convert_value_to_term(__yices_globals.manager, __yices_globals.terms, vtbl, v);
-  if (value_term < 0 ||
-      ! is_subtype(__yices_globals.types, term_type(__yices_globals.terms, value_term), tau)) {
+  if (! check_value_type(vtbl, v, tau)) {
     set_error_code(TYPE_MISMATCH);
     return -1;
   }
@@ -10311,7 +10325,6 @@ int32_t _o_yices_model_make_function(model_t *model, type_t fun_type, uint32_t n
   value_t def_v;
   value_t f;
   value_map_t *m;
-  term_t t;
   type_t range;
   uint32_t i, j, arity;
 
@@ -10330,8 +10343,7 @@ int32_t _o_yices_model_make_function(model_t *model, type_t fun_type, uint32_t n
     return -1;
   }
 
-  t = convert_value_to_term(__yices_globals.manager, __yices_globals.terms, vtbl, def_v);
-  if (t < 0 || ! is_subtype(types, term_type(__yices_globals.terms, t), range)) {
+  if (! check_value_type(vtbl, def_v, range)) {
     set_error_code(TYPE_MISMATCH);
     return -1;
   }
@@ -10356,17 +10368,14 @@ int32_t _o_yices_model_make_function(model_t *model, type_t fun_type, uint32_t n
     }
 
     for (j = 0; j < arity; j++) {
-      t = convert_value_to_term(__yices_globals.manager, __yices_globals.terms, vtbl, m->arg[j]);
-      if (t < 0 ||
-          ! is_subtype(types, term_type(__yices_globals.terms, t), function_type_domain(types, fun_type, (int32_t) j))) {
+      if (! check_value_type(vtbl, m->arg[j], function_type_domain(types, fun_type, (int32_t) j))) {
         safe_free(a);
         set_error_code(TYPE_MISMATCH);
         return -1;
       }
     }
 
-    t = convert_value_to_term(__yices_globals.manager, __yices_globals.terms, vtbl, m->val);
-    if (t < 0 || ! is_subtype(types, term_type(__yices_globals.terms, t), range)) {
+    if (! check_value_type(vtbl, m->val, range)) {
       safe_free(a);
       set_error_code(TYPE_MISMATCH);
       return -1;

--- a/src/api/yices_api.c
+++ b/src/api/yices_api.c
@@ -10183,9 +10183,26 @@ EXPORTED int32_t yices_model_set_yval(model_t *model, term_t var, const yval_t *
   MT_PROTECT(int32_t, __yices_globals.lock, _o_yices_model_set_yval(model, var, yval));
 }
 
+/*
+ * Check that yval refers to a valid object in vtbl and that the tag is consistent.
+ * If valid, store the referenced value in *v.
+ */
+static bool check_model_yval(value_table_t *vtbl, const yval_t *yval, value_t *v) {
+  *v = yval->node_id;
+  if (! good_object(vtbl, *v) ||
+      yval->node_tag != tag_for_valkind(object_kind(vtbl, *v))) {
+    set_error_code(TYPE_MISMATCH);
+    return false;
+  }
+
+  return true;
+}
+
 int32_t _o_yices_model_set_yval(model_t *model, term_t var, const yval_t *yval) {
   value_table_t *vtbl;
   value_t v;
+  term_t value_term;
+  type_t tau;
   
   if (! check_good_term(__yices_globals.manager, var) ||
       ! check_uninterpreted(__yices_globals.terms, var) ||
@@ -10194,15 +10211,200 @@ int32_t _o_yices_model_set_yval(model_t *model, term_t var, const yval_t *yval) 
   }
 
   vtbl = model_get_vtbl(model);
-  v = yval->node_id;
-  
-  // Check that the yval is a valid object
-  if (! good_object(vtbl, v)) {
+  if (! check_model_yval(vtbl, yval, &v)) {
+    return -1;
+  }
+
+  tau = term_type(__yices_globals.terms, var);
+  value_term = convert_value_to_term(__yices_globals.manager, __yices_globals.terms, vtbl, v);
+  if (value_term < 0 ||
+      ! is_subtype(__yices_globals.types, term_type(__yices_globals.terms, value_term), tau)) {
     set_error_code(TYPE_MISMATCH);
     return -1;
   }
 
   model_map_term(model, var, v);
+  return 0;
+}
+
+EXPORTED int32_t yices_model_make_tuple(model_t *model, uint32_t n, const yval_t elem[], yval_t *tuple) {
+  MT_PROTECT(int32_t, __yices_globals.lock, _o_yices_model_make_tuple(model, n, elem, tuple));
+}
+
+int32_t _o_yices_model_make_tuple(model_t *model, uint32_t n, const yval_t elem[], yval_t *tuple) {
+  value_table_t *vtbl;
+  value_t v;
+  value_t *a;
+  uint32_t i;
+
+  vtbl = model_get_vtbl(model);
+  a = (value_t *) safe_malloc(n * sizeof(value_t));
+
+  for (i = 0; i < n; i++) {
+    if (! check_model_yval(vtbl, elem + i, a + i)) {
+      safe_free(a);
+      return -1;
+    }
+  }
+
+  v = vtbl_mk_tuple(vtbl, n, a);
+  safe_free(a);
+  get_yval(vtbl, v, tuple);
+
+  return 0;
+}
+
+EXPORTED int32_t yices_model_set_tuple(model_t *model, term_t var, uint32_t n, const yval_t elem[]) {
+  MT_PROTECT(int32_t, __yices_globals.lock, _o_yices_model_set_tuple(model, var, n, elem));
+}
+
+int32_t _o_yices_model_set_tuple(model_t *model, term_t var, uint32_t n, const yval_t elem[]) {
+  yval_t tuple;
+
+  if (_o_yices_model_make_tuple(model, n, elem, &tuple) < 0) {
+    return -1;
+  }
+
+  return _o_yices_model_set_yval(model, var, &tuple);
+}
+
+EXPORTED int32_t yices_model_make_mapping(model_t *model, uint32_t arity, const yval_t args[], const yval_t *value, yval_t *mapping) {
+  MT_PROTECT(int32_t, __yices_globals.lock, _o_yices_model_make_mapping(model, arity, args, value, mapping));
+}
+
+int32_t _o_yices_model_make_mapping(model_t *model, uint32_t arity, const yval_t args[], const yval_t *value, yval_t *mapping) {
+  value_table_t *vtbl;
+  value_t v;
+  value_t *a;
+  uint32_t i;
+
+  vtbl = model_get_vtbl(model);
+  a = (value_t *) safe_malloc(arity * sizeof(value_t));
+
+  for (i = 0; i < arity; i++) {
+    if (! check_model_yval(vtbl, args + i, a + i)) {
+      safe_free(a);
+      return -1;
+    }
+  }
+
+  if (! check_model_yval(vtbl, value, &v)) {
+    safe_free(a);
+    return -1;
+  }
+
+  v = vtbl_mk_map(vtbl, arity, a, v);
+  safe_free(a);
+  get_yval(vtbl, v, mapping);
+
+  return 0;
+}
+
+EXPORTED int32_t yices_model_make_function(model_t *model, type_t fun_type, uint32_t n, const yval_t mappings[], const yval_t *def, yval_t *fun) {
+  MT_PROTECT(int32_t, __yices_globals.lock, _o_yices_model_make_function(model, fun_type, n, mappings, def, fun));
+}
+
+int32_t _o_yices_model_make_function(model_t *model, type_t fun_type, uint32_t n, const yval_t mappings[], const yval_t *def, yval_t *fun) {
+  type_table_t *types;
+  value_table_t *vtbl;
+  value_t *a;
+  value_t def_v;
+  value_t f;
+  value_map_t *m;
+  term_t t;
+  type_t range;
+  uint32_t i, j, arity;
+
+  if (! check_good_type(__yices_globals.types, fun_type) ||
+      ! is_function_type(__yices_globals.types, fun_type)) {
+    set_error_code(TYPE_MISMATCH);
+    return -1;
+  }
+
+  types = __yices_globals.types;
+  vtbl = model_get_vtbl(model);
+  arity = function_type_arity(types, fun_type);
+  range = function_type_range(types, fun_type);
+
+  if (! check_model_yval(vtbl, def, &def_v)) {
+    return -1;
+  }
+
+  t = convert_value_to_term(__yices_globals.manager, __yices_globals.terms, vtbl, def_v);
+  if (t < 0 || ! is_subtype(types, term_type(__yices_globals.terms, t), range)) {
+    set_error_code(TYPE_MISMATCH);
+    return -1;
+  }
+
+  a = (value_t *) safe_malloc(n * sizeof(value_t));
+  for (i = 0; i < n; i++) {
+    if (! check_model_yval(vtbl, mappings + i, a + i)) {
+      safe_free(a);
+      return -1;
+    }
+    if (! object_is_map(vtbl, a[i])) {
+      safe_free(a);
+      set_error_code(TYPE_MISMATCH);
+      return -1;
+    }
+
+    m = vtbl_map(vtbl, a[i]);
+    if (m->arity != arity) {
+      safe_free(a);
+      set_error_code(TYPE_MISMATCH);
+      return -1;
+    }
+
+    for (j = 0; j < arity; j++) {
+      t = convert_value_to_term(__yices_globals.manager, __yices_globals.terms, vtbl, m->arg[j]);
+      if (t < 0 ||
+          ! is_subtype(types, term_type(__yices_globals.terms, t), function_type_domain(types, fun_type, (int32_t) j))) {
+        safe_free(a);
+        set_error_code(TYPE_MISMATCH);
+        return -1;
+      }
+    }
+
+    t = convert_value_to_term(__yices_globals.manager, __yices_globals.terms, vtbl, m->val);
+    if (t < 0 || ! is_subtype(types, term_type(__yices_globals.terms, t), range)) {
+      safe_free(a);
+      set_error_code(TYPE_MISMATCH);
+      return -1;
+    }
+  }
+
+  f = vtbl_mk_function(vtbl, fun_type, n, a, def_v);
+  safe_free(a);
+  get_yval(vtbl, f, fun);
+
+  return 0;
+}
+
+EXPORTED int32_t yices_model_set_function(model_t *model, term_t var, uint32_t n, const yval_t mappings[], const yval_t *def) {
+  MT_PROTECT(int32_t, __yices_globals.lock, _o_yices_model_set_function(model, var, n, mappings, def));
+}
+
+int32_t _o_yices_model_set_function(model_t *model, term_t var, uint32_t n, const yval_t mappings[], const yval_t *def) {
+  yval_t fun;
+  type_t tau;
+
+  if (! check_good_term(__yices_globals.manager, var) ||
+      ! check_uninterpreted(__yices_globals.terms, var) ||
+      ! check_unassigned_in_model(model, var)) {
+    return -1;
+  }
+
+  tau = term_type(__yices_globals.terms, var);
+  if (! is_function_type(__yices_globals.types, tau)) {
+    set_error_code(TYPE_MISMATCH);
+    return -1;
+  }
+
+  if (_o_yices_model_make_function(model, tau, n, mappings, def, &fun) < 0) {
+    return -1;
+  }
+
+  model_map_term(model, var, fun.node_id);
   return 0;
 }
 

--- a/src/api/yices_api_lock_free.h
+++ b/src/api/yices_api_lock_free.h
@@ -656,6 +656,16 @@ extern int32_t _o_yices_model_set_float(model_t *model, term_t var, float val);
 
 extern int32_t _o_yices_model_set_yval(model_t *model, term_t var, const yval_t *yval);
 
+extern int32_t _o_yices_model_make_tuple(model_t *model, uint32_t n, const yval_t elem[], yval_t *tuple);
+
+extern int32_t _o_yices_model_set_tuple(model_t *model, term_t var, uint32_t n, const yval_t elem[]);
+
+extern int32_t _o_yices_model_make_mapping(model_t *model, uint32_t arity, const yval_t args[], const yval_t *value, yval_t *mapping);
+
+extern int32_t _o_yices_model_make_function(model_t *model, type_t fun_type, uint32_t n, const yval_t mappings[], const yval_t *def, yval_t *fun);
+
+extern int32_t _o_yices_model_set_function(model_t *model, term_t var, uint32_t n, const yval_t mappings[], const yval_t *def);
+
 /************************
  *  VALUES IN A MODEL   *
  ***********************/

--- a/src/api/yval.c
+++ b/src/api/yval.c
@@ -103,8 +103,8 @@ static const yval_tag_t val_kind2tag[NUM_VALUE_KIND] = {
   YVAL_UNKNOWN,    // UNKNOWN_VALUE
   YVAL_BOOL,       // BOOLEAN_VALUE
   YVAL_RATIONAL,   // RATIONAL_VALUE
-  YVAL_FINITEFIELD,// FINITEFIELD_VALUE
   YVAL_ALGEBRAIC,  // ALGEBRAIC_VALUE
+  YVAL_FINITEFIELD,// FINITEFIELD_VALUE
   YVAL_BV,         // BITVECTOR_VALUE
   YVAL_TUPLE,      // TUPPLE_VALUE
   YVAL_SCALAR,     // UNINTERPRETED_VALUE
@@ -214,4 +214,3 @@ void yval_expand_update(value_table_t *tbl, value_t f, yval_vector_t *v, yval_t 
     yval_vector_push(v, x, YVAL_MAPPING);
   }
 }
-

--- a/src/include/yices.h
+++ b/src/include/yices.h
@@ -4953,15 +4953,74 @@ __YICES_DLLSPEC__ extern int32_t yices_model_set_term(model_t *model, term_t var
 /*
  * Assign a yval_t value to an uninterpreted symbol in the model.
  * - var = uninterpreted symbol
- * - yval = value descriptor (possibly from another model)
+ * - yval = value descriptor from the same model
  * - var must not have a value in model
  * - yval must be compatible with var's type
+ * - the value HAS to come from the same model
  *
  * Returns 0 on success, -1 on error (sets error code).
  *
  * Since 2.7.0
  */
 __YICES_DLLSPEC__ extern int32_t yices_model_set_yval(model_t *model, term_t var, const yval_t *yval);
+
+/*
+ * Build a tuple value from an array of yval_t descriptors.
+ * - elem[0 ... n-1] must all refer to values from the same model
+ * - tuple is set to a descriptor for the tuple value built in model
+ *
+ * Returns 0 on success, -1 on error (sets error code).
+ *
+ * Since 2.7.0
+ */
+__YICES_DLLSPEC__ extern int32_t yices_model_make_tuple(model_t *model, uint32_t n, const yval_t elem[], yval_t *tuple);
+
+/*
+ * Assign a tuple value built from elem[0 ... n-1] to an uninterpreted symbol.
+ * - var = uninterpreted symbol
+ * - var must not have a value in model
+ * - elem[0 ... n-1] must all refer to values from the same model
+ * - the tuple's type must be compatible with var's type
+ *
+ * Returns 0 on success, -1 on error (sets error code).
+ *
+ * Since 2.7.0
+ */
+__YICES_DLLSPEC__ extern int32_t yices_model_set_tuple(model_t *model, term_t var, uint32_t n, const yval_t elem[]);
+
+/*
+ * Build a mapping value [args[0] ... args[arity-1] -> value].
+ * - all descriptors must refer to values from the same model
+ *
+ * Returns 0 on success, -1 on error (sets error code).
+ *
+ * Since 2.7.0
+ */
+__YICES_DLLSPEC__ extern int32_t yices_model_make_mapping(model_t *model, uint32_t arity, const yval_t args[], const yval_t *value, yval_t *mapping);
+
+/*
+ * Build a function value of type fun_type from an array of mapping descriptors and a default value.
+ * - fun_type must be a function type
+ * - all descriptors must refer to values from the same model
+ * - mappings must have the right arity and type-compatible argument/result values
+ * - def must be type-compatible with fun_type's range
+ *
+ * Returns 0 on success, -1 on error (sets error code).
+ *
+ * Since 2.7.0
+ */
+__YICES_DLLSPEC__ extern int32_t yices_model_make_function(model_t *model, type_t fun_type, uint32_t n, const yval_t mappings[], const yval_t *def, yval_t *fun);
+
+/*
+ * Assign a function value built from mappings/default to an uninterpreted symbol.
+ * - var must have function type and must not already have a value in model
+ * - all descriptors must refer to values from the same model
+ *
+ * Returns 0 on success, -1 on error (sets error code).
+ *
+ * Since 2.7.0
+ */
+__YICES_DLLSPEC__ extern int32_t yices_model_set_function(model_t *model, term_t var, uint32_t n, const yval_t mappings[], const yval_t *def);
 
 
 #ifdef __cplusplus

--- a/src/model/concrete_values.c
+++ b/src/model/concrete_values.c
@@ -578,6 +578,8 @@ static void hset_normalize(map_hset_t *hset) {
  * - ttbl = attached type table.
  */
 void init_value_table(value_table_t *table, uint32_t n, type_table_t *ttbl) {
+  uint32_t i;
+
   if (n == 0) {
     n = DEF_VALUE_TABLE_SIZE;
   }
@@ -589,6 +591,10 @@ void init_value_table(value_table_t *table, uint32_t n, type_table_t *ttbl) {
   table->nobjects = 0;
   table->kind = (uint8_t *) safe_malloc(n * sizeof(uint8_t));
   table->desc = (value_desc_t *) safe_malloc(n * sizeof(value_desc_t));
+  table->type_cache = (type_t *) safe_malloc(n * sizeof(type_t));
+  for (i=0; i<n; i++) {
+    table->type_cache[i] = NULL_TYPE;
+  }
   table->canonical = allocate_bitvector0(n);
 
   table->type_table = ttbl;
@@ -620,8 +626,9 @@ void init_value_table(value_table_t *table, uint32_t n, type_table_t *ttbl) {
  * Make the table larger (by 50%)
  */
 static void extend_value_table(value_table_t *table) {
-  uint32_t n;
+  uint32_t i, n, old_n;
 
+  old_n = table->size;
   n = table->size + 1;
   n += n>>1;
   assert(n > table->size);
@@ -633,7 +640,11 @@ static void extend_value_table(value_table_t *table) {
   table->size = n;
   table->kind = (uint8_t *) safe_realloc(table->kind, n * sizeof(uint8_t));
   table->desc = (value_desc_t *) safe_realloc(table->desc, n * sizeof(value_desc_t));
-  table->canonical = extend_bitvector0(table->canonical, n, table->size);
+  table->type_cache = (type_t *) safe_realloc(table->type_cache, n * sizeof(type_t));
+  for (i=old_n; i<n; i++) {
+    table->type_cache[i] = NULL_TYPE;
+  }
+  table->canonical = extend_bitvector0(table->canonical, old_n, n);
 }
 
 
@@ -649,6 +660,7 @@ static value_t allocate_object(value_table_t *table) {
     extend_value_table(table);
   }
   assert(i < table->size);
+  table->type_cache[i] = NULL_TYPE;
   table->nobjects = i+1;
   return i;
 }
@@ -779,6 +791,8 @@ static void vtbl_delete_descriptors(value_table_t *table, uint32_t k) {
  * - empty the table.
  */
 void reset_value_table(value_table_t *table) {
+  uint32_t i;
+
   vtbl_delete_descriptors(table, 0);
   reset_int_htbl(&table->htbl);
   reset_map_htbl(&table->mtbl);
@@ -788,6 +802,9 @@ void reset_value_table(value_table_t *table) {
   ivector_reset(&table->aux_vector);
 
   table->nobjects = 0;
+  for (i=0; i<table->size; i++) {
+    table->type_cache[i] = NULL_TYPE;
+  }
   table->unknown_value = null_value;
   table->true_value = null_value;
   table->false_value = null_value;
@@ -802,6 +819,7 @@ void delete_value_table(value_table_t *table) {
   vtbl_delete_descriptors(table, 0);
   safe_free(table->kind);
   safe_free(table->desc);
+  safe_free(table->type_cache);
   delete_bitvector(table->canonical);
   delete_int_htbl(&table->htbl);
   delete_bvconstant(&table->buffer);
@@ -811,7 +829,92 @@ void delete_value_table(value_table_t *table) {
   delete_hsets(table);
   table->kind = NULL;
   table->desc = NULL;
+  table->type_cache = NULL;
   table->canonical = NULL;
+}
+
+/*
+ * Compute and cache the type of value v.
+ * - returns NULL_TYPE if no type can be inferred.
+ */
+type_t vtbl_value_type(value_table_t *table, value_t v) {
+  type_t tau;
+  type_t *a;
+  value_kind_t kind;
+  value_tuple_t *tuple;
+  value_unint_t *u;
+  value_fun_t *fun;
+  value_ff_t *v_ff;
+  uint32_t i, n;
+
+  assert(good_object(table, v));
+
+  tau = table->type_cache[v];
+  if (tau != NULL_TYPE) {
+    return tau;
+  }
+
+  kind = object_kind(table, v);
+  switch (kind) {
+  case BOOLEAN_VALUE:
+    tau = bool_type(table->type_table);
+    break;
+
+  case RATIONAL_VALUE:
+    tau = object_is_integer(table, v) ? int_type(table->type_table) : real_type(table->type_table);
+    break;
+
+  case ALGEBRAIC_VALUE:
+    tau = real_type(table->type_table);
+    break;
+
+  case FINITEFIELD_VALUE:
+    v_ff = vtbl_finitefield(table, v);
+    tau = ff_type_r(table->type_table, &v_ff->mod);
+    break;
+
+  case BITVECTOR_VALUE:
+    tau = bv_type(table->type_table, vtbl_bitvector(table, v)->nbits);
+    break;
+
+  case UNINTERPRETED_VALUE:
+    u = vtbl_unint(table, v);
+    tau = u->type;
+    break;
+
+  case TUPLE_VALUE:
+    tuple = vtbl_tuple(table, v);
+    n = tuple->nelems;
+    a = (type_t *) safe_malloc(n * sizeof(type_t));
+    for (i=0; i<n; i++) {
+      a[i] = vtbl_value_type(table, tuple->elem[i]);
+      if (a[i] == NULL_TYPE) {
+        safe_free(a);
+        return NULL_TYPE;
+      }
+    }
+    tau = tuple_type(table->type_table, n, a);
+    safe_free(a);
+    break;
+
+  case FUNCTION_VALUE:
+    fun = vtbl_function(table, v);
+    tau = fun->type;
+    break;
+
+  case UPDATE_VALUE:
+    tau = vtbl_function_type(table, v);
+    break;
+
+  case UNKNOWN_VALUE:
+  case MAP_VALUE:
+  default:
+    tau = NULL_TYPE;
+    break;
+  }
+
+  table->type_cache[v] = tau;
+  return tau;
 }
 
 

--- a/src/model/concrete_values.c
+++ b/src/model/concrete_values.c
@@ -644,7 +644,7 @@ static void extend_value_table(value_table_t *table) {
   for (i=old_n; i<n; i++) {
     table->type_cache[i] = NULL_TYPE;
   }
-  table->canonical = extend_bitvector0(table->canonical, old_n, n);
+  table->canonical = extend_bitvector0(table->canonical, n, old_n);
 }
 
 

--- a/src/model/concrete_values.h
+++ b/src/model/concrete_values.h
@@ -333,6 +333,7 @@ typedef struct value_table_s {
   uint32_t nobjects;
   uint8_t *kind;
   value_desc_t *desc;
+  type_t *type_cache;
   byte_t *canonical; // bitvector
 
   type_table_t *type_table;
@@ -969,6 +970,13 @@ static inline value_update_t *vtbl_update(value_table_t *table, value_t v) {
   assert(object_is_update(table, v));
   return (value_update_t *) table->desc[v].ptr;
 }
+
+/*
+ * Get the most specific type known for value v.
+ * - returns NULL_TYPE if no type can be inferred (e.g., UNKNOWN/MAP value).
+ * - result is cached in table->type_cache.
+ */
+extern type_t vtbl_value_type(value_table_t *table, value_t v);
 
 
 /*

--- a/src/model/val_to_term.c
+++ b/src/model/val_to_term.c
@@ -224,6 +224,10 @@ term_t convert_simple_value(term_table_t *terms, value_table_t *vtbl, value_t v)
     t = convert_rational(terms, vtbl, v);
     break;
 
+  case ALGEBRAIC_VALUE:
+    t = CONVERT_FAILED;
+    break;
+
   case FINITEFIELD_VALUE:
     t = convert_finitefield(terms, vtbl, v);
     break;
@@ -325,7 +329,7 @@ static const int32_t convert_code[NUM_VALUE_KIND] = {
   CONVERT_UNKNOWN_VALUE,  // UNKNOWN_VALUE
   0,                      // BOOLEAN_VALUE
   0,                      // RATIONAL_VALUE
-  0,                      // ALGEBRAIC_VALUE
+  CONVERT_FAILED,         // ALGEBRAIC_VALUE
   0,                      // FINITEFIELD_VALUE
   0,                      // BITVECTOR_VALUE
   0,                      // TUPLE_VALUE
@@ -359,6 +363,14 @@ term_t convert_val(val_converter_t *convert, value_t v) {
     t = convert_cached_term(convert, v);
     if (t < 0) {
       t = convert_rational(convert->terms, vtbl, v);
+      convert_cache_map(convert, v, t);
+    }
+    break;
+
+  case FINITEFIELD_VALUE:
+    t = convert_cached_term(convert, v);
+    if (t < 0) {
+      t = convert_finitefield(convert->terms, vtbl, v);
       convert_cache_map(convert, v, t);
     }
     break;
@@ -470,4 +482,3 @@ uint32_t convert_value_array(term_manager_t *mgr, term_table_t *terms, value_tab
 
   return s;
 }
-

--- a/tests/api/doc_model_composite_yval_example.c
+++ b/tests/api/doc_model_composite_yval_example.c
@@ -1,0 +1,106 @@
+/*
+ * Compile/run checked version of the model-operations composite yval example.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <yices.h>
+
+int main(void) {
+  model_t *model;
+  type_t int_type, bool_type, tuple_type, fun_type;
+  term_t x, y, b, t, f, fxy, fyx;
+  yval_t xv, yv, bv, tuple_v, map_v, false_v, fun_v;
+  yval_t tuple_elems[3], map_args[2], maps[1];
+  yval_t tuple_children[3];
+  int32_t bval, ival;
+
+  yices_init();
+
+  model = yices_new_model();
+  assert(model != NULL);
+
+  int_type = yices_int_type();
+  bool_type = yices_bool_type();
+  tuple_type = yices_tuple_type3(int_type, int_type, bool_type);
+  fun_type = yices_function_type2(int_type, int_type, bool_type);
+
+  x = yices_new_uninterpreted_term(int_type);
+  y = yices_new_uninterpreted_term(int_type);
+  b = yices_new_uninterpreted_term(bool_type);
+  t = yices_new_uninterpreted_term(tuple_type);
+  f = yices_new_uninterpreted_term(fun_type);
+
+  if (yices_model_set_int32(model, x, 3) != 0 ||
+      yices_model_set_int32(model, y, 5) != 0 ||
+      yices_model_set_bool(model, b, 1) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+
+  if (yices_get_value(model, x, &xv) != 0 ||
+      yices_get_value(model, y, &yv) != 0 ||
+      yices_get_value(model, b, &bv) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+
+  // Tuple: (x, y, b)
+  tuple_elems[0] = xv;
+  tuple_elems[1] = yv;
+  tuple_elems[2] = bv;
+  if (yices_model_make_tuple(model, 3, tuple_elems, &tuple_v) != 0 ||
+      yices_model_set_tuple(model, t, 3, tuple_elems) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+
+  if (yices_get_value(model, t, &tuple_v) != 0 ||
+      yices_val_expand_tuple(model, &tuple_v, tuple_children) != 0 ||
+      yices_val_get_int32(model, &tuple_children[0], &ival) != 0 ||
+      ival != 3) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+
+  // Mapping: [x, y -> b]
+  map_args[0] = xv;
+  map_args[1] = yv;
+  if (yices_model_make_mapping(model, 2, map_args, &bv, &map_v) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+
+  // Function with one mapping and default false
+  if (yices_get_value(model, yices_false(), &false_v) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+  maps[0] = map_v;
+  if (yices_model_make_function(model, fun_type, 1, maps, &false_v, &fun_v) != 0 ||
+      yices_model_set_function(model, f, 1, maps, &false_v) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+
+  // f(x, y) = true from mapping
+  fxy = yices_application2(f, x, y);
+  if (yices_get_bool_value(model, fxy, &bval) != 0 || bval != 1) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+
+  // f(y, x) = false from default
+  fyx = yices_application2(f, y, x);
+  if (yices_get_bool_value(model, fyx, &bval) != 0 || bval != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+
+  yices_free_model(model);
+  yices_exit();
+  printf("All tests passed!\n");
+
+  return 0;
+}

--- a/tests/api/test_model_set_double_float_term_yval.c
+++ b/tests/api/test_model_set_double_float_term_yval.c
@@ -89,12 +89,17 @@ static void test_term_model_setting(void) {
 static void test_yval_model_setting(void) {
   type_t int_type = yices_int_type();
   type_t bool_type = yices_bool_type();
+  type_t fun_type = yices_function_type1(int_type, bool_type);
   term_t var1 = yices_new_uninterpreted_term(int_type);
   term_t var2 = yices_new_uninterpreted_term(int_type);
   term_t var3 = yices_new_uninterpreted_term(bool_type);
+  term_t var_fun = yices_new_uninterpreted_term(fun_type);
   model_t *model = yices_new_model();
   yval_t yval;
   yval_t bad_tag_yval;
+  yval_t yval_false;
+  yval_t map_args[1];
+  yval_t map_yval;
   int32_t ival;
 
   // Set var1 in model
@@ -145,6 +150,23 @@ static void test_yval_model_setting(void) {
     yices_print_error(stderr);
   }
 
+  // Error: MAP yval is not a value type (forces NULL_TYPE path in type inference)
+  if (yices_get_value(model, yices_false(), &yval_false) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+  map_args[0] = yval;
+  if (yices_model_make_mapping(model, 1, map_args, &yval_false, &map_yval) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+  if (yices_model_set_yval(model, var_fun, &map_yval) >= 0) {
+    fprintf(stderr, "Expected error for MAP yval assigned via set_yval, but call succeeded\n");
+    exit(1);
+  } else {
+    yices_print_error(stderr);
+  }
+
   yices_free_model(model);
 }
 
@@ -155,6 +177,7 @@ static void test_tuple_model_setting(void) {
   term_t int_var = yices_new_uninterpreted_term(int_type);
   term_t bool_var = yices_new_uninterpreted_term(bool_type);
   term_t tuple_var = yices_new_uninterpreted_term(tuple_type);
+  term_t tuple_var2 = yices_new_uninterpreted_term(tuple_type);
   model_t *model = yices_new_model();
   yval_t int_yval;
   yval_t bool_yval;
@@ -190,6 +213,12 @@ static void test_tuple_model_setting(void) {
 
   // Assign tuple value via dedicated API
   if (yices_model_set_tuple(model, tuple_var, 2, elem) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+
+  // Also assign via generic yval API (covers tuple type inference recursion)
+  if (yices_model_set_yval(model, tuple_var2, &tuple_yval) != 0) {
     yices_print_error(stderr);
     exit(1);
   }
@@ -234,6 +263,7 @@ static void test_function_model_setting(void) {
   term_t bool_var_true = yices_new_uninterpreted_term(bool_type);
   term_t bool_var_false = yices_new_uninterpreted_term(bool_type);
   term_t fun_var = yices_new_uninterpreted_term(fun_type);
+  term_t fun_var2 = yices_new_uninterpreted_term(fun_type);
   model_t *model = yices_new_model();
   yval_t arg0;
   yval_t arg1;
@@ -309,12 +339,50 @@ static void test_function_model_setting(void) {
     exit(1);
   }
 
+  // Assign function via generic yval API (covers FUNCTION_VALUE type inference)
+  if (yices_model_set_yval(model, fun_var2, &fun) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+
   // Error: invalid mapping descriptor
   bad_map = map0;
   bad_map.node_tag = YVAL_BOOL;
   maps[0] = bad_map;
   if (yices_model_make_function(model, fun_type, 2, maps, &def, &fun) >= 0) {
     fprintf(stderr, "Expected error for invalid mapping descriptor, but call succeeded\n");
+    exit(1);
+  } else {
+    yices_print_error(stderr);
+  }
+
+  // Error: default has wrong type
+  if (yices_model_make_function(model, fun_type, 2, (const yval_t[]){ map0, map1 }, &arg0, &fun) >= 0) {
+    fprintf(stderr, "Expected error for invalid default value type, but call succeeded\n");
+    exit(1);
+  } else {
+    yices_print_error(stderr);
+  }
+
+  // Error: argument type mismatch in mapping
+  if (yices_model_make_mapping(model, 1, (const yval_t[]){ val_true }, &val_true, &map0) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+  if (yices_model_make_function(model, fun_type, 1, (const yval_t[]){ map0 }, &def, &fun) >= 0) {
+    fprintf(stderr, "Expected error for invalid mapping argument type, but call succeeded\n");
+    exit(1);
+  } else {
+    yices_print_error(stderr);
+  }
+
+  // Error: result type mismatch in mapping
+  if (yices_model_make_mapping(model, 1, (const yval_t[]){ arg0 }, &arg0, &map0) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+  if (yices_model_make_function(model, fun_type, 1, (const yval_t[]){ map0 }, &def, &fun) >= 0) {
+    fprintf(stderr, "Expected error for invalid mapping result type, but call succeeded\n");
     exit(1);
   } else {
     yices_print_error(stderr);

--- a/tests/api/test_model_set_double_float_term_yval.c
+++ b/tests/api/test_model_set_double_float_term_yval.c
@@ -323,6 +323,109 @@ static void test_function_model_setting(void) {
   yices_free_model(model);
 }
 
+#if HAVE_MCSAT
+static void test_algebraic_leaf_tuple_and_function_values(void) {
+  ctx_config_t *cfg;
+  context_t *ctx;
+  model_t *model;
+  term_t x, minus_x, eq, tuple_var, fun_var;
+  type_t tuple_type, fun_type;
+  yval_t x_yval, minus_x_yval, tuple_yval, fun_yval;
+  yval_t tuple_elem[2];
+  yval_t tuple_child[2];
+  yval_t int0_yval, map_yval, def_yval, maps[1], map_args[1];
+  int32_t code;
+  smt_status_t status;
+  double d0, d1, d2;
+
+  // Build a model where x is algebraic: x^2 = 2
+  cfg = yices_new_config();
+  assert(cfg != NULL);
+  code = yices_default_config_for_logic(cfg, "QF_NRA");
+  assert(code == 0);
+  ctx = yices_new_context(cfg);
+  assert(ctx != NULL);
+  yices_free_config(cfg);
+
+  x = yices_new_uninterpreted_term(yices_real_type());
+  minus_x = yices_neg(x);
+  eq = yices_parse_term("(= (* x x) 2)");
+  assert(x != NULL_TERM && minus_x != NULL_TERM && eq != NULL_TERM);
+  code = yices_assert_formula(ctx, eq);
+  if (code != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+
+  status = yices_check_context(ctx, NULL);
+  if (status != YICES_STATUS_SAT) {
+    fprintf(stderr, "Expected SAT status in algebraic example\n");
+    exit(1);
+  }
+  model = yices_get_model(ctx, true);
+  assert(model != NULL);
+
+  code = yices_get_value(model, x, &x_yval);
+  assert(code == 0 && x_yval.node_tag == YVAL_ALGEBRAIC);
+  code = yices_get_value(model, minus_x, &minus_x_yval);
+  assert(code == 0 && minus_x_yval.node_tag == YVAL_ALGEBRAIC);
+
+  // Tuple with algebraic leaves
+  tuple_type = yices_tuple_type2(yices_real_type(), yices_real_type());
+  tuple_var = yices_new_uninterpreted_term(tuple_type);
+  tuple_elem[0] = x_yval;
+  tuple_elem[1] = minus_x_yval;
+
+  code = yices_model_make_tuple(model, 2, tuple_elem, &tuple_yval);
+  assert(code == 0 && tuple_yval.node_tag == YVAL_TUPLE);
+  code = yices_model_set_tuple(model, tuple_var, 2, tuple_elem);
+  assert(code == 0);
+  code = yices_get_value(model, tuple_var, &tuple_yval);
+  assert(code == 0 && tuple_yval.node_tag == YVAL_TUPLE);
+  code = yices_val_expand_tuple(model, &tuple_yval, tuple_child);
+  assert(code == 0);
+  assert(tuple_child[0].node_tag == YVAL_ALGEBRAIC);
+  assert(tuple_child[1].node_tag == YVAL_ALGEBRAIC);
+
+  code = yices_val_get_double(model, &tuple_child[0], &d0);
+  assert(code == 0);
+  code = yices_val_get_double(model, &tuple_child[1], &d1);
+  assert(code == 0);
+  // Second tuple component should be the negation of the first.
+  assert(d0 * d1 < 0.0);
+
+  // Function Int -> Real with algebraic leaves
+  fun_type = yices_function_type1(yices_int_type(), yices_real_type());
+  fun_var = yices_new_uninterpreted_term(fun_type);
+
+  code = yices_get_value(model, yices_int32(0), &int0_yval);
+  assert(code == 0);
+  map_args[0] = int0_yval;
+  code = yices_model_make_mapping(model, 1, map_args, &minus_x_yval, &map_yval);
+  assert(code == 0 && map_yval.node_tag == YVAL_MAPPING);
+
+  maps[0] = map_yval;
+  def_yval = x_yval;
+  code = yices_model_make_function(model, fun_type, 1, maps, &def_yval, &fun_yval);
+  assert(code == 0 && fun_yval.node_tag == YVAL_FUNCTION);
+  code = yices_model_set_function(model, fun_var, 1, maps, &def_yval);
+  assert(code == 0);
+
+  // f(0) = -x from mapping
+  code = yices_get_double_value(model, yices_application1(fun_var, yices_int32(0)), &d2);
+  assert(code == 0);
+  assert(d2 * d1 > 0.0);
+
+  // f(1) = x from default
+  code = yices_get_double_value(model, yices_application1(fun_var, yices_int32(1)), &d2);
+  assert(code == 0);
+  assert(d2 * d0 > 0.0);
+
+  yices_free_model(model);
+  yices_free_context(ctx);
+}
+#endif
+
 int main(void) {
   yices_init();
 
@@ -331,6 +434,11 @@ int main(void) {
   test_yval_model_setting();
   test_tuple_model_setting();
   test_function_model_setting();
+#if HAVE_MCSAT
+  if (yices_has_mcsat()) {
+    test_algebraic_leaf_tuple_and_function_values();
+  }
+#endif
 
   printf("All tests passed!\n");
 

--- a/tests/api/test_model_set_double_float_term_yval.c
+++ b/tests/api/test_model_set_double_float_term_yval.c
@@ -88,10 +88,13 @@ static void test_term_model_setting(void) {
 
 static void test_yval_model_setting(void) {
   type_t int_type = yices_int_type();
+  type_t bool_type = yices_bool_type();
   term_t var1 = yices_new_uninterpreted_term(int_type);
   term_t var2 = yices_new_uninterpreted_term(int_type);
+  term_t var3 = yices_new_uninterpreted_term(bool_type);
   model_t *model = yices_new_model();
   yval_t yval;
+  yval_t bad_tag_yval;
   int32_t ival;
 
   // Set var1 in model
@@ -124,6 +127,199 @@ static void test_yval_model_setting(void) {
     yices_print_error(stderr);
   }
 
+  // Error: bad yval tag
+  bad_tag_yval = yval;
+  bad_tag_yval.node_tag = YVAL_BOOL;
+  if (yices_model_set_yval(model, var3, &bad_tag_yval) >= 0) {
+    fprintf(stderr, "Expected error for setting yval with wrong tag, but call succeeded\n");
+    exit(1);
+  } else {
+    yices_print_error(stderr);
+  }
+
+  // Error: type mismatch (integer yval assigned to boolean var)
+  if (yices_model_set_yval(model, var3, &yval) >= 0) {
+    fprintf(stderr, "Expected error for type mismatch in set_yval, but call succeeded\n");
+    exit(1);
+  } else {
+    yices_print_error(stderr);
+  }
+
+  yices_free_model(model);
+}
+
+static void test_tuple_model_setting(void) {
+  type_t int_type = yices_int_type();
+  type_t bool_type = yices_bool_type();
+  type_t tuple_type = yices_tuple_type2(int_type, bool_type);
+  term_t int_var = yices_new_uninterpreted_term(int_type);
+  term_t bool_var = yices_new_uninterpreted_term(bool_type);
+  term_t tuple_var = yices_new_uninterpreted_term(tuple_type);
+  model_t *model = yices_new_model();
+  yval_t int_yval;
+  yval_t bool_yval;
+  yval_t tuple_yval;
+  yval_t elem[2];
+  yval_t child[2];
+  yval_t bad_tag;
+  int32_t ival;
+  int32_t bval;
+  int32_t code;
+
+  if (yices_model_set_int32(model, int_var, 10) != 0 ||
+      yices_model_set_bool(model, bool_var, 1) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+
+  if (yices_get_value(model, int_var, &int_yval) != 0 ||
+      yices_get_value(model, bool_var, &bool_yval) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+
+  elem[0] = int_yval;
+  elem[1] = bool_yval;
+
+  // Build tuple value from yvals
+  if (yices_model_make_tuple(model, 2, elem, &tuple_yval) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+  assert(tuple_yval.node_tag == YVAL_TUPLE);
+
+  // Assign tuple value via dedicated API
+  if (yices_model_set_tuple(model, tuple_var, 2, elem) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+
+  if (yices_get_value(model, tuple_var, &tuple_yval) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+  if (yices_val_expand_tuple(model, &tuple_yval, child) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+  if (yices_val_get_int32(model, &child[0], &ival) != 0 ||
+      yices_val_get_bool(model, &child[1], &bval) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+  assert(ival == 10);
+  assert(bval == 1);
+
+  // Error: bad descriptor tag in tuple builder
+  bad_tag = int_yval;
+  bad_tag.node_tag = YVAL_BOOL;
+  elem[0] = bad_tag;
+  code = yices_model_make_tuple(model, 2, elem, &tuple_yval);
+  if (code >= 0) {
+    fprintf(stderr, "Expected error for invalid yval tag in tuple builder, but call succeeded\n");
+    exit(1);
+  } else {
+    yices_print_error(stderr);
+  }
+
+  yices_free_model(model);
+}
+
+static void test_function_model_setting(void) {
+  type_t int_type = yices_int_type();
+  type_t bool_type = yices_bool_type();
+  type_t fun_type = yices_function_type1(int_type, bool_type);
+  term_t int_var0 = yices_new_uninterpreted_term(int_type);
+  term_t int_var1 = yices_new_uninterpreted_term(int_type);
+  term_t bool_var_true = yices_new_uninterpreted_term(bool_type);
+  term_t bool_var_false = yices_new_uninterpreted_term(bool_type);
+  term_t fun_var = yices_new_uninterpreted_term(fun_type);
+  model_t *model = yices_new_model();
+  yval_t arg0;
+  yval_t arg1;
+  yval_t val_true;
+  yval_t val_false;
+  yval_t def;
+  yval_t map0;
+  yval_t map1;
+  yval_t maps[2];
+  yval_t args[1];
+  yval_t bad_map;
+  yval_t fun;
+  term_t app0, app1, app2;
+  int32_t b;
+
+  if (yices_model_set_int32(model, int_var0, 0) != 0 ||
+      yices_model_set_int32(model, int_var1, 1) != 0 ||
+      yices_model_set_bool(model, bool_var_true, 1) != 0 ||
+      yices_model_set_bool(model, bool_var_false, 0) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+
+  if (yices_get_value(model, int_var0, &arg0) != 0 ||
+      yices_get_value(model, int_var1, &arg1) != 0 ||
+      yices_get_value(model, bool_var_true, &val_true) != 0 ||
+      yices_get_value(model, bool_var_false, &val_false) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+  def = val_false;
+
+  args[0] = arg0;
+  if (yices_model_make_mapping(model, 1, args, &val_true, &map0) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+  args[0] = arg1;
+  if (yices_model_make_mapping(model, 1, args, &val_false, &map1) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+  assert(map0.node_tag == YVAL_MAPPING);
+  assert(map1.node_tag == YVAL_MAPPING);
+
+  maps[0] = map0;
+  maps[1] = map1;
+
+  if (yices_model_make_function(model, fun_type, 2, maps, &def, &fun) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+  assert(fun.node_tag == YVAL_FUNCTION);
+
+  if (yices_model_set_function(model, fun_var, 2, maps, &def) != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+
+  app0 = yices_application1(fun_var, yices_int32(0));
+  app1 = yices_application1(fun_var, yices_int32(1));
+  app2 = yices_application1(fun_var, yices_int32(2));
+  if (yices_get_bool_value(model, app0, &b) != 0 || b != 1) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+  if (yices_get_bool_value(model, app1, &b) != 0 || b != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+  if (yices_get_bool_value(model, app2, &b) != 0 || b != 0) {
+    yices_print_error(stderr);
+    exit(1);
+  }
+
+  // Error: invalid mapping descriptor
+  bad_map = map0;
+  bad_map.node_tag = YVAL_BOOL;
+  maps[0] = bad_map;
+  if (yices_model_make_function(model, fun_type, 2, maps, &def, &fun) >= 0) {
+    fprintf(stderr, "Expected error for invalid mapping descriptor, but call succeeded\n");
+    exit(1);
+  } else {
+    yices_print_error(stderr);
+  }
+
   yices_free_model(model);
 }
 
@@ -133,6 +329,8 @@ int main(void) {
   test_double_float_model_setting();
   test_term_model_setting();
   test_yval_model_setting();
+  test_tuple_model_setting();
+  test_function_model_setting();
 
   printf("All tests passed!\n");
 

--- a/tests/api/test_model_set_double_float_term_yval.c
+++ b/tests/api/test_model_set_double_float_term_yval.c
@@ -349,7 +349,7 @@ static void test_algebraic_leaf_tuple_and_function_values(void) {
 
   x = yices_new_uninterpreted_term(yices_real_type());
   minus_x = yices_neg(x);
-  eq = yices_parse_term("(= (* x x) 2)");
+  eq = yices_arith_eq_atom(yices_square(x), yices_int32(2));
   assert(x != NULL_TERM && minus_x != NULL_TERM && eq != NULL_TERM);
   code = yices_assert_formula(ctx, eq);
   if (code != 0) {
@@ -444,4 +444,4 @@ int main(void) {
 
   yices_exit();
   return 0;
-} 
+}


### PR DESCRIPTION
This PR strengthens model-value assignment semantics and extends the API for composite values built from yval_t descriptors.

1) Harden yices_model_set_yval
Enforces that the descriptor refers to a valid value in the same model.
Enforces descriptor/tag consistency (node_tag must match actual value kind).
Enforces type compatibility with the target variable before assignment.
2) Clarify same-model semantics in docs
yices_model_set_yval documentation now explicitly states that the value must come from the same model instance.
3) Add tuple/function builder APIs from yval_t arrays
Added:
yices_model_make_tuple
yices_model_set_tuple
yices_model_make_mapping
yices_model_make_function
yices_model_set_function
All these APIs validate model consistency of input descriptors and perform type checks for tuple/function construction.
4) Add/extend API tests
Added negative tests for set_yval tag/type mismatch.
Added tuple/function construction tests.
Added examples with algebraic leaves (MCSAT-enabled builds): building tuple and function values from algebraic yval_t values and validating results.