### PR TITLE
Fix #608 bug: MCSAT + Thread-Safe Lock Recursion and Add API Regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
           env: ${{ matrix.env }}
       - name: Test
         uses: ./.github/actions/test
+        env:
+          TIME_LIMIT: ${{ matrix.mode == 'gcov' && contains(matrix.config-opt, '--enable-thread-safety') && contains(matrix.config-opt, '--enable-mcsat') && '120' || '60' }}
         with:
           mode: ${{ matrix.mode }}
       - name: Coverage
@@ -110,6 +112,8 @@ jobs:
           env: ${{ matrix.env }}
       - name: Test
         uses: ./.github/actions/test
+        env:
+          TIME_LIMIT: ${{ matrix.mode == 'gcov' && contains(matrix.config-opt, '--enable-thread-safety') && contains(matrix.config-opt, '--enable-mcsat') && '120' || '60' }}
         with:
           mode: ${{ matrix.mode }}
       - name: Coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         uses: ./.github/actions/test
         env:
           TIME_LIMIT: ${{ matrix.mode == 'gcov' && contains(matrix.config-opt, '--enable-thread-safety') && contains(matrix.config-opt, '--enable-mcsat') && '120' || '60' }}
-          REGRESS_EXCLUDE_FILTER: ${{ matrix.mode == 'gcov' && contains(matrix.config-opt, '--enable-thread-safety') && contains(matrix.config-opt, '--enable-mcsat') && 'tests/regress/iss517.smt2' || '' }}
+          REGRESS_EXCLUDE_FILTER: ${{ matrix.mode == 'gcov' && contains(matrix.config-opt, '--enable-thread-safety') && contains(matrix.config-opt, '--enable-mcsat') && 'iss517.smt2$' || '' }}
         with:
           mode: ${{ matrix.mode }}
       - name: Coverage
@@ -115,7 +115,7 @@ jobs:
         uses: ./.github/actions/test
         env:
           TIME_LIMIT: ${{ matrix.mode == 'gcov' && contains(matrix.config-opt, '--enable-thread-safety') && contains(matrix.config-opt, '--enable-mcsat') && '120' || '60' }}
-          REGRESS_EXCLUDE_FILTER: ${{ matrix.mode == 'gcov' && contains(matrix.config-opt, '--enable-thread-safety') && contains(matrix.config-opt, '--enable-mcsat') && 'tests/regress/iss517.smt2' || '' }}
+          REGRESS_EXCLUDE_FILTER: ${{ matrix.mode == 'gcov' && contains(matrix.config-opt, '--enable-thread-safety') && contains(matrix.config-opt, '--enable-mcsat') && 'iss517.smt2$' || '' }}
         with:
           mode: ${{ matrix.mode }}
       - name: Coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,10 @@ jobs:
         with:
           mode: ${{ matrix.mode }}
       - name: Coverage
-        if: matrix.mode == 'gcov'
+        if: matrix.mode == 'gcov' && matrix.config-opt == '--enable-mcsat'
         uses: ./.github/actions/coverage
       - name: Coveralls
-        if: matrix.mode == 'gcov'
+        if: matrix.mode == 'gcov' && matrix.config-opt == '--enable-mcsat'
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -117,10 +117,10 @@ jobs:
         with:
           mode: ${{ matrix.mode }}
       - name: Coverage
-        if: matrix.mode == 'gcov'
+        if: matrix.mode == 'gcov' && matrix.config-opt == '--enable-mcsat'
         uses: ./.github/actions/coverage
       - name: Coveralls
-        if: matrix.mode == 'gcov'
+        if: matrix.mode == 'gcov' && matrix.config-opt == '--enable-mcsat'
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
         uses: ./.github/actions/test
         env:
           TIME_LIMIT: ${{ matrix.mode == 'gcov' && contains(matrix.config-opt, '--enable-thread-safety') && contains(matrix.config-opt, '--enable-mcsat') && '120' || '60' }}
+          REGRESS_EXCLUDE_FILTER: ${{ matrix.mode == 'gcov' && contains(matrix.config-opt, '--enable-thread-safety') && contains(matrix.config-opt, '--enable-mcsat') && 'tests/regress/iss517.smt2' || '' }}
         with:
           mode: ${{ matrix.mode }}
       - name: Coverage
@@ -114,6 +115,7 @@ jobs:
         uses: ./.github/actions/test
         env:
           TIME_LIMIT: ${{ matrix.mode == 'gcov' && contains(matrix.config-opt, '--enable-thread-safety') && contains(matrix.config-opt, '--enable-mcsat') && '120' || '60' }}
+          REGRESS_EXCLUDE_FILTER: ${{ matrix.mode == 'gcov' && contains(matrix.config-opt, '--enable-thread-safety') && contains(matrix.config-opt, '--enable-mcsat') && 'tests/regress/iss517.smt2' || '' }}
         with:
           mode: ${{ matrix.mode }}
       - name: Coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,18 @@ jobs:
             mode: gcov
             config-opt: --enable-mcsat
             env: CC=gcc-13 CXX=g++-13
+          - os: ubuntu-latest
+            mode: debug
+            config-opt: --enable-thread-safety --enable-mcsat
+            env: CC=gcc CXX=g++
+          - os: ubuntu-latest
+            mode: release
+            config-opt: --enable-thread-safety --enable-mcsat
+            env: CC=gcc CXX=g++
+          - os: ubuntu-latest
+            mode: gcov
+            config-opt: --enable-thread-safety --enable-mcsat
+            env: CC=gcc-13 CXX=g++-13
     name: ${{ matrix.os }}|${{ matrix.mode }}|${{ matrix.config-opt }}|${{ matrix.env }} (push)
     runs-on: ${{ matrix.os }}
     steps:
@@ -68,6 +80,22 @@ jobs:
             mode: debug
             config-opt: --enable-thread-safety --enable-mcsat
             env: CC=gcc CXX=g++
+          - os: ubuntu-latest
+            mode: release
+            config-opt: --enable-thread-safety --enable-mcsat
+            env: CC=gcc CXX=g++
+          - os: ubuntu-latest
+            mode: gcov
+            config-opt: --enable-thread-safety --enable-mcsat
+            env: CC=gcc-13 CXX=g++-13
+          - os: macos-latest
+            mode: debug
+            config-opt: --enable-thread-safety --enable-mcsat
+            env: CC=clang CXX=clang++
+          - os: macos-latest
+            mode: release
+            config-opt: --enable-thread-safety --enable-mcsat
+            env: CC=clang CXX=clang++
     name: ${{ matrix.os }}|${{ matrix.mode }}|${{ matrix.config-opt }}|${{ matrix.env }} (pr)
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - run: git config --global core.autocrlf input
+    - run: git config --global core.autocrlf false && git config --global core.eol lf
 
     - uses: actions/checkout@v4
 
@@ -51,7 +51,7 @@ jobs:
         CYGWIN: winsymlinks:native binmode
       run: >-
         mkdir -p /tools/mcsat_deps &&
-        git clone https://github.com/SRI-CSL/libpoly.git &&
+        git -c core.autocrlf=false clone https://github.com/SRI-CSL/libpoly.git &&
         sed -i 's/tracef("f\\[%zu\\] = ", i);/tracef("f[%u] = ", (unsigned) i);/g' libpoly/src/number/algebraic_number.c &&
         mkdir -p libpoly/build-mingw &&
         cd libpoly/build-mingw &&
@@ -59,13 +59,14 @@ jobs:
         make &&
         make install &&
         cd ../.. &&
-        git clone https://github.com/ivmai/cudd.git &&
+        git -c core.autocrlf=false clone https://github.com/ivmai/cudd.git &&
         cd cudd &&
         git checkout tags/cudd-3.0.0 &&
         sed -i 's/\r$//' configure &&
         find build-aux -type f -exec sed -i 's/\r$//' {} + &&
         chmod +x configure build-aux/* &&
         ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --disable-shared --enable-static --disable-dependency-tracking --disable-maintainer-mode --prefix=/tools/mcsat_deps &&
+        make config.h &&
         test -f config.status && sed -i 's/\r$//' config.status || true &&
         test -f libtool && sed -i 's/\r$//' libtool || true &&
         make &&

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -73,21 +73,25 @@ jobs:
         make &&
         make install
 
-    - name: Building Yices
+    - name: Building Yices (non-MCSAT)
+      if: "!contains(matrix.config-opt, '--enable-mcsat')"
       shell: bash
       env:
         CYGWIN: winsymlinks:native
       run: >-
-        mcsat_cppflags="" &&
-        mcsat_ldflags="" &&
-        mcsat_options="" &&
-        if [[ "${{ matrix.config-opt }}" == *"--enable-mcsat"* ]]; then
-          mcsat_cppflags="-I/tools/mcsat_deps/include";
-          mcsat_ldflags="-L/tools/mcsat_deps/lib";
-          mcsat_options="--with-static-libpoly=/tools/mcsat_deps/lib/libpoly.a --with-static-libpoly-include-dir=/tools/mcsat_deps/include";
-        fi &&
         autoconf &&
-        ./configure ${{ matrix.config-opt }} --host=x86_64-w64-mingw32 CPPFLAGS="-I/tools/dynamic_gmp/include ${mcsat_cppflags}" LDFLAGS="-L/tools/dynamic_gmp/lib ${mcsat_ldflags}" --with-static-gmp=/tools/static_gmp/lib/libgmp.a --with-static-gmp-include-dir=/tools/static_gmp/include ${mcsat_options} &&
+        ./configure ${{ matrix.config-opt }} --host=x86_64-w64-mingw32 CPPFLAGS="-I/tools/dynamic_gmp/include" LDFLAGS="-L/tools/dynamic_gmp/lib" --with-static-gmp=/tools/static_gmp/lib/libgmp.a --with-static-gmp-include-dir=/tools/static_gmp/include &&
+        export LD_LIBRARY_PATH=/usr/local/lib/:${LD_LIBRARY_PATH} &&
+        make OPTION=mingw64 MODE=${{ matrix.mode }}
+
+    - name: Building Yices (MCSAT)
+      if: contains(matrix.config-opt, '--enable-mcsat')
+      shell: bash
+      env:
+        CYGWIN: winsymlinks:native
+      run: >-
+        autoconf &&
+        ./configure ${{ matrix.config-opt }} --host=x86_64-w64-mingw32 CPPFLAGS="-I/tools/dynamic_gmp/include -I/tools/mcsat_deps/include" LDFLAGS="-L/tools/dynamic_gmp/lib -L/tools/mcsat_deps/lib" --with-static-gmp=/tools/static_gmp/lib/libgmp.a --with-static-gmp-include-dir=/tools/static_gmp/include --with-static-libpoly=/tools/mcsat_deps/lib/libpoly.a --with-static-libpoly-include-dir=/tools/mcsat_deps/include &&
         export LD_LIBRARY_PATH=/usr/local/lib/:${LD_LIBRARY_PATH} &&
         make OPTION=mingw64 MODE=${{ matrix.mode }}
 

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -42,44 +42,29 @@ jobs:
       shell: bash
       env:
         CYGWIN: winsymlinks:native
-      run: |
-        pushd .
-        mkdir -p /tools
-        cd /tools
-        mkdir -p dynamic_gmp static_gmp
-
-        gmp_archive=gmp-6.3.0.tar.xz
-        download_ok=0
-        for url in \
-          https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz \
-          https://mirrors.kernel.org/gnu/gmp/gmp-6.3.0.tar.xz \
-          https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz
-        do
-          echo "Trying $url"
-          if curl -fL --retry 5 --retry-delay 2 --connect-timeout 20 --max-time 600 "$url" -o "$gmp_archive"; then
-            download_ok=1
-            break
-          fi
-          if wget --tries=5 --timeout=20 -O "$gmp_archive" "$url"; then
-            download_ok=1
-            break
-          fi
-        done
-
-        if [ "$download_ok" -ne 1 ]; then
-          echo "Failed to download $gmp_archive from all mirrors"
-          exit 1
-        fi
-
-        tar xf "$gmp_archive"
-        cd gmp-6.3.0
-        ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --enable-cxx --enable-shared --disable-static --prefix=/tools/dynamic_gmp
-        make
-        make install
-        make clean
-        ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --enable-cxx --enable-static --disable-shared --prefix=/tools/static_gmp
-        make
-        make install
+      run: >-
+        pushd . &&
+        mkdir -p /tools &&
+        cd /tools &&
+        mkdir -p dynamic_gmp static_gmp &&
+        gmp_archive=gmp-6.3.0.tar.xz &&
+        (
+          curl -fL --retry 5 --retry-delay 2 --connect-timeout 20 --max-time 600 https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz -o "$gmp_archive" ||
+          wget --tries=5 --timeout=20 -O "$gmp_archive" https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz ||
+          curl -fL --retry 5 --retry-delay 2 --connect-timeout 20 --max-time 600 https://mirrors.kernel.org/gnu/gmp/gmp-6.3.0.tar.xz -o "$gmp_archive" ||
+          wget --tries=5 --timeout=20 -O "$gmp_archive" https://mirrors.kernel.org/gnu/gmp/gmp-6.3.0.tar.xz ||
+          curl -fL --retry 5 --retry-delay 2 --connect-timeout 20 --max-time 600 https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz -o "$gmp_archive" ||
+          wget --tries=5 --timeout=20 -O "$gmp_archive" https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz
+        ) &&
+        tar xf "$gmp_archive" &&
+        cd gmp-6.3.0 &&
+        ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --enable-cxx --enable-shared --disable-static --prefix=/tools/dynamic_gmp &&
+        make &&
+        make install &&
+        make clean &&
+        ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --enable-cxx --enable-static --disable-shared --prefix=/tools/static_gmp &&
+        make &&
+        make install &&
         popd
 
     - name: Building MCSAT Dependencies

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -25,11 +25,13 @@ jobs:
         # Packages to install
         packages: |
           autoconf,
+          cmake,
           coreutils,
           gperf,
           m4,
           make,
           mingw64-x86_64-gcc-core,
+          mingw64-x86_64-gcc-g++,
           moreutils,
           wget
 
@@ -49,14 +51,64 @@ jobs:
         make && make install && 
         popd
 
+    - name: Building MCSAT Dependencies
+      if: contains(matrix.config-opt, '--enable-mcsat')
+      shell: bash
+      env:
+        CYGWIN: winsymlinks:native
+      run: |
+        set -eux
+        mkdir -p /tools/mcsat_deps
+
+        git clone https://github.com/SRI-CSL/libpoly.git
+        mkdir -p libpoly/build-mingw
+        cd libpoly/build-mingw
+        cmake .. \
+          -DCMAKE_SYSTEM_NAME=Windows \
+          -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc \
+          -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ \
+          -DCMAKE_INSTALL_PREFIX=/tools/mcsat_deps \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DGMP_LIBRARY=/tools/static_gmp/lib/libgmp.a \
+          -DGMP_INCLUDE_DIR=/tools/static_gmp/include
+        make
+        make install
+        cd ../..
+
+        git clone https://github.com/ivmai/cudd.git
+        cd cudd
+        git checkout tags/cudd-3.0.0
+        autoreconf -fi
+        ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --disable-shared --enable-static --prefix=/tools/mcsat_deps
+        make
+        make install
+
     - name: Building Yices
       shell: bash
       env:
         CYGWIN: winsymlinks:native
-      run: >-
-        autoconf && 
-        ./configure ${{ matrix.config-opt }} --host=x86_64-w64-mingw32 CPPFLAGS=-I/tools/dynamic_gmp/include LDFLAGS=-L/tools/dynamic_gmp/lib --with-static-gmp=/tools/static_gmp/lib/libgmp.a --with-static-gmp-include-dir=/tools/static_gmp/include && 
-        export LD_LIBRARY_PATH=/usr/local/lib/:${LD_LIBRARY_PATH} && 
+      run: |
+        set -eux
+        autoconf
+
+        mcsat_cppflags=""
+        mcsat_ldflags=""
+        mcsat_options=""
+        if [[ "${{ matrix.config-opt }}" == *"--enable-mcsat"* ]]; then
+          mcsat_cppflags="-I/tools/mcsat_deps/include"
+          mcsat_ldflags="-L/tools/mcsat_deps/lib"
+          mcsat_options="--with-static-libpoly=/tools/mcsat_deps/lib/libpoly.a --with-static-libpoly-include-dir=/tools/mcsat_deps/include"
+        fi
+
+        ./configure ${{ matrix.config-opt }} \
+          --host=x86_64-w64-mingw32 \
+          CPPFLAGS="-I/tools/dynamic_gmp/include ${mcsat_cppflags}" \
+          LDFLAGS="-L/tools/dynamic_gmp/lib ${mcsat_ldflags}" \
+          --with-static-gmp=/tools/static_gmp/lib/libgmp.a \
+          --with-static-gmp-include-dir=/tools/static_gmp/include \
+          ${mcsat_options}
+
+        export LD_LIBRARY_PATH=/usr/local/lib/:${LD_LIBRARY_PATH}
         make OPTION=mingw64 MODE=${{ matrix.mode }}
 
     - name: Run Yices API Tests

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -72,6 +72,8 @@ jobs:
         cd cudd &&
         git checkout tags/cudd-3.0.0 &&
         sed -i 's/\r$//' configure &&
+        sed -i 's/\r$//' build-aux/config.sub build-aux/config.guess &&
+        chmod +x configure build-aux/config.sub build-aux/config.guess &&
         ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --disable-shared --enable-static --prefix=/tools/mcsat_deps &&
         make &&
         make install

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -59,10 +59,10 @@ jobs:
       run: >-
         mkdir -p /tools/mcsat_deps &&
         git clone https://github.com/SRI-CSL/libpoly.git &&
-        sed -i 's/tracef("f[%zu] = ", i);/tracef("f[%u] = ", (unsigned) i);/g' libpoly/src/number/algebraic_number.c &&
+        sed -i 's/tracef("f\\[%zu\\] = ", i);/tracef("f[%u] = ", (unsigned) i);/g' libpoly/src/number/algebraic_number.c &&
         mkdir -p libpoly/build-mingw &&
         cd libpoly/build-mingw &&
-        cmake .. -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_INSTALL_PREFIX=/tools/mcsat_deps -DBUILD_SHARED_LIBS=OFF -DGMP_LIBRARY=/tools/static_gmp/lib/libgmp.a -DGMP_INCLUDE_DIR=/tools/static_gmp/include -DCMAKE_C_FLAGS='-D__USE_MINGW_ANSI_STDIO -Wno-error=format' -DCMAKE_CXX_FLAGS='-D__USE_MINGW_ANSI_STDIO -Wno-error=format' &&
+        cmake .. -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_INSTALL_PREFIX=/tools/mcsat_deps -DBUILD_SHARED_LIBS=OFF -DGMP_LIBRARY=/tools/static_gmp/lib/libgmp.a -DGMP_INCLUDE_DIR=/tools/static_gmp/include -DCMAKE_C_FLAGS='-D__USE_MINGW_ANSI_STDIO -Wno-error=format -Wno-error=format-extra-args' -DCMAKE_CXX_FLAGS='-D__USE_MINGW_ANSI_STDIO -Wno-error=format -Wno-error=format-extra-args' &&
         make &&
         make install &&
         cd ../.. &&

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -72,9 +72,9 @@ jobs:
         cd cudd &&
         git checkout tags/cudd-3.0.0 &&
         sed -i 's/\r$//' configure &&
-        sed -i 's/\r$//' build-aux/config.sub build-aux/config.guess &&
-        chmod +x configure build-aux/config.sub build-aux/config.guess &&
-        ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --disable-shared --enable-static --prefix=/tools/mcsat_deps &&
+        find build-aux -type f -exec sed -i 's/\r$//' {} + &&
+        chmod +x configure build-aux/* &&
+        ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --disable-shared --enable-static --disable-dependency-tracking --prefix=/tools/mcsat_deps &&
         make &&
         make install
 

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -71,7 +71,6 @@ jobs:
         git clone https://github.com/ivmai/cudd.git &&
         cd cudd &&
         git checkout tags/cudd-3.0.0 &&
-        autoreconf -fi &&
         ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --disable-shared --enable-static --prefix=/tools/mcsat_deps &&
         make &&
         make install

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -28,6 +28,7 @@ jobs:
           automake,
           cmake,
           coreutils,
+          curl,
           gperf,
           libtool,
           m4,
@@ -41,16 +42,44 @@ jobs:
       shell: bash
       env:
         CYGWIN: winsymlinks:native
-      run: >-
-        pushd . && 
-        mkdir -p /tools && cd /tools && mkdir -p dynamic_gmp && mkdir -p static_gmp && 
-        wget https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz &&
-        tar xf gmp-6.3.0.tar.xz && 
-        cd gmp-6.3.0 &&
-        ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --enable-cxx --enable-shared --disable-static --prefix=/tools/dynamic_gmp &&
-        make && make install && make clean && 
-        ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --enable-cxx --enable-static --disable-shared --prefix=/tools/static_gmp && 
-        make && make install && 
+      run: |
+        pushd .
+        mkdir -p /tools
+        cd /tools
+        mkdir -p dynamic_gmp static_gmp
+
+        gmp_archive=gmp-6.3.0.tar.xz
+        download_ok=0
+        for url in \
+          https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz \
+          https://mirrors.kernel.org/gnu/gmp/gmp-6.3.0.tar.xz \
+          https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz
+        do
+          echo "Trying $url"
+          if curl -fL --retry 5 --retry-delay 2 --connect-timeout 20 --max-time 600 "$url" -o "$gmp_archive"; then
+            download_ok=1
+            break
+          fi
+          if wget --tries=5 --timeout=20 -O "$gmp_archive" "$url"; then
+            download_ok=1
+            break
+          fi
+        done
+
+        if [ "$download_ok" -ne 1 ]; then
+          echo "Failed to download $gmp_archive from all mirrors"
+          exit 1
+        fi
+
+        tar xf "$gmp_archive"
+        cd gmp-6.3.0
+        ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --enable-cxx --enable-shared --disable-static --prefix=/tools/dynamic_gmp
+        make
+        make install
+        make clean
+        ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --enable-cxx --enable-static --disable-shared --prefix=/tools/static_gmp
+        make
+        make install
         popd
 
     - name: Building MCSAT Dependencies

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -56,59 +56,39 @@ jobs:
       shell: bash
       env:
         CYGWIN: winsymlinks:native
-      run: |
-        set -eux
-        mkdir -p /tools/mcsat_deps
-
-        git clone https://github.com/SRI-CSL/libpoly.git
-        mkdir -p libpoly/build-mingw
-        cd libpoly/build-mingw
-        cmake .. \
-          -DCMAKE_SYSTEM_NAME=Windows \
-          -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc \
-          -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ \
-          -DCMAKE_INSTALL_PREFIX=/tools/mcsat_deps \
-          -DBUILD_SHARED_LIBS=OFF \
-          -DGMP_LIBRARY=/tools/static_gmp/lib/libgmp.a \
-          -DGMP_INCLUDE_DIR=/tools/static_gmp/include
-        make
-        make install
-        cd ../..
-
-        git clone https://github.com/ivmai/cudd.git
-        cd cudd
-        git checkout tags/cudd-3.0.0
-        autoreconf -fi
-        ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --disable-shared --enable-static --prefix=/tools/mcsat_deps
-        make
+      run: >-
+        mkdir -p /tools/mcsat_deps &&
+        git clone https://github.com/SRI-CSL/libpoly.git &&
+        mkdir -p libpoly/build-mingw &&
+        cd libpoly/build-mingw &&
+        cmake .. -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_INSTALL_PREFIX=/tools/mcsat_deps -DBUILD_SHARED_LIBS=OFF -DGMP_LIBRARY=/tools/static_gmp/lib/libgmp.a -DGMP_INCLUDE_DIR=/tools/static_gmp/include &&
+        make &&
+        make install &&
+        cd ../.. &&
+        git clone https://github.com/ivmai/cudd.git &&
+        cd cudd &&
+        git checkout tags/cudd-3.0.0 &&
+        autoreconf -fi &&
+        ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --disable-shared --enable-static --prefix=/tools/mcsat_deps &&
+        make &&
         make install
 
     - name: Building Yices
       shell: bash
       env:
         CYGWIN: winsymlinks:native
-      run: |
-        set -eux
-        autoconf
-
-        mcsat_cppflags=""
-        mcsat_ldflags=""
-        mcsat_options=""
+      run: >-
+        mcsat_cppflags="" &&
+        mcsat_ldflags="" &&
+        mcsat_options="" &&
         if [[ "${{ matrix.config-opt }}" == *"--enable-mcsat"* ]]; then
-          mcsat_cppflags="-I/tools/mcsat_deps/include"
-          mcsat_ldflags="-L/tools/mcsat_deps/lib"
-          mcsat_options="--with-static-libpoly=/tools/mcsat_deps/lib/libpoly.a --with-static-libpoly-include-dir=/tools/mcsat_deps/include"
-        fi
-
-        ./configure ${{ matrix.config-opt }} \
-          --host=x86_64-w64-mingw32 \
-          CPPFLAGS="-I/tools/dynamic_gmp/include ${mcsat_cppflags}" \
-          LDFLAGS="-L/tools/dynamic_gmp/lib ${mcsat_ldflags}" \
-          --with-static-gmp=/tools/static_gmp/lib/libgmp.a \
-          --with-static-gmp-include-dir=/tools/static_gmp/include \
-          ${mcsat_options}
-
-        export LD_LIBRARY_PATH=/usr/local/lib/:${LD_LIBRARY_PATH}
+          mcsat_cppflags="-I/tools/mcsat_deps/include";
+          mcsat_ldflags="-L/tools/mcsat_deps/lib";
+          mcsat_options="--with-static-libpoly=/tools/mcsat_deps/lib/libpoly.a --with-static-libpoly-include-dir=/tools/mcsat_deps/include";
+        fi &&
+        autoconf &&
+        ./configure ${{ matrix.config-opt }} --host=x86_64-w64-mingw32 CPPFLAGS="-I/tools/dynamic_gmp/include ${mcsat_cppflags}" LDFLAGS="-L/tools/dynamic_gmp/lib ${mcsat_ldflags}" --with-static-gmp=/tools/static_gmp/lib/libgmp.a --with-static-gmp-include-dir=/tools/static_gmp/include ${mcsat_options} &&
+        export LD_LIBRARY_PATH=/usr/local/lib/:${LD_LIBRARY_PATH} &&
         make OPTION=mingw64 MODE=${{ matrix.mode }}
 
     - name: Run Yices API Tests

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -45,9 +45,9 @@ jobs:
         wget https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz &&
         tar xf gmp-6.3.0.tar.xz && 
         cd gmp-6.3.0 &&
-        ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --enable-shared --disable-static --prefix=/tools/dynamic_gmp &&
+        ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --enable-cxx --enable-shared --disable-static --prefix=/tools/dynamic_gmp &&
         make && make install && make clean && 
-        ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --enable-static --disable-shared --prefix=/tools/static_gmp && 
+        ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --enable-cxx --enable-static --disable-shared --prefix=/tools/static_gmp && 
         make && make install && 
         popd
 
@@ -62,7 +62,7 @@ jobs:
         sed -i 's/tracef("f\\[%zu\\] = ", i);/tracef("f[%u] = ", (unsigned) i);/g' libpoly/src/number/algebraic_number.c &&
         mkdir -p libpoly/build-mingw &&
         cd libpoly/build-mingw &&
-        cmake .. -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_INSTALL_PREFIX=/tools/mcsat_deps -DBUILD_SHARED_LIBS=OFF -DGMP_LIBRARY=/tools/static_gmp/lib/libgmp.a -DGMP_INCLUDE_DIR=/tools/static_gmp/include -DCMAKE_C_FLAGS='-D__USE_MINGW_ANSI_STDIO -Wno-error=format -Wno-error=format-extra-args' -DCMAKE_CXX_FLAGS='-D__USE_MINGW_ANSI_STDIO -Wno-error=format -Wno-error=format-extra-args' &&
+        cmake .. -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_INSTALL_PREFIX=/tools/mcsat_deps -DBUILD_SHARED_LIBS=OFF -DGMP_LIBRARY=/tools/static_gmp/lib/libgmp.a -DGMP_INCLUDE_DIR=/tools/static_gmp/include -DGMPXX_LIBRARY=/tools/static_gmp/lib/libgmpxx.a -DGMPXX_INCLUDE_DIR=/tools/static_gmp/include -DCMAKE_C_FLAGS='-D__USE_MINGW_ANSI_STDIO -Wno-error=format -Wno-error=format-extra-args' -DCMAKE_CXX_FLAGS='-D__USE_MINGW_ANSI_STDIO -Wno-error=format -Wno-error=format-extra-args' &&
         make &&
         make install &&
         cd ../.. &&

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -42,30 +42,7 @@ jobs:
       shell: bash
       env:
         CYGWIN: winsymlinks:native
-      run: >-
-        pushd . &&
-        mkdir -p /tools &&
-        cd /tools &&
-        mkdir -p dynamic_gmp static_gmp &&
-        gmp_archive=gmp-6.3.0.tar.xz &&
-        (
-          curl -fL --retry 5 --retry-delay 2 --connect-timeout 20 --max-time 600 https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz -o "$gmp_archive" ||
-          wget --tries=5 --timeout=20 -O "$gmp_archive" https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz ||
-          curl -fL --retry 5 --retry-delay 2 --connect-timeout 20 --max-time 600 https://mirrors.kernel.org/gnu/gmp/gmp-6.3.0.tar.xz -o "$gmp_archive" ||
-          wget --tries=5 --timeout=20 -O "$gmp_archive" https://mirrors.kernel.org/gnu/gmp/gmp-6.3.0.tar.xz ||
-          curl -fL --retry 5 --retry-delay 2 --connect-timeout 20 --max-time 600 https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz -o "$gmp_archive" ||
-          wget --tries=5 --timeout=20 -O "$gmp_archive" https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz
-        ) &&
-        tar xf "$gmp_archive" &&
-        cd gmp-6.3.0 &&
-        ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --enable-cxx --enable-shared --disable-static --prefix=/tools/dynamic_gmp &&
-        make &&
-        make install &&
-        make clean &&
-        ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --enable-cxx --enable-static --disable-shared --prefix=/tools/static_gmp &&
-        make &&
-        make install &&
-        popd
+      run: pushd . && mkdir -p /tools && cd /tools && mkdir -p dynamic_gmp static_gmp && gmp_archive=gmp-6.3.0.tar.xz && (curl -fL --retry 5 --retry-delay 2 --connect-timeout 20 --max-time 600 https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz -o "$gmp_archive" || wget --tries=5 --timeout=20 -O "$gmp_archive" https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz || curl -fL --retry 5 --retry-delay 2 --connect-timeout 20 --max-time 600 https://mirrors.kernel.org/gnu/gmp/gmp-6.3.0.tar.xz -o "$gmp_archive" || wget --tries=5 --timeout=20 -O "$gmp_archive" https://mirrors.kernel.org/gnu/gmp/gmp-6.3.0.tar.xz || curl -fL --retry 5 --retry-delay 2 --connect-timeout 20 --max-time 600 https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz -o "$gmp_archive" || wget --tries=5 --timeout=20 -O "$gmp_archive" https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz) && tar xf "$gmp_archive" && cd gmp-6.3.0 && ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --enable-cxx --enable-shared --disable-static --prefix=/tools/dynamic_gmp && make && make install && make clean && ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --enable-cxx --enable-static --disable-shared --prefix=/tools/static_gmp && make && make install && popd
 
     - name: Building MCSAT Dependencies
       if: contains(matrix.config-opt, '--enable-mcsat')

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -59,6 +59,7 @@ jobs:
       run: >-
         mkdir -p /tools/mcsat_deps &&
         git clone https://github.com/SRI-CSL/libpoly.git &&
+        sed -i 's/tracef("f[%zu] = ", i);/tracef("f[%u] = ", (unsigned) i);/g' libpoly/src/number/algebraic_number.c &&
         mkdir -p libpoly/build-mingw &&
         cd libpoly/build-mingw &&
         cmake .. -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_INSTALL_PREFIX=/tools/mcsat_deps -DBUILD_SHARED_LIBS=OFF -DGMP_LIBRARY=/tools/static_gmp/lib/libgmp.a -DGMP_INCLUDE_DIR=/tools/static_gmp/include -DCMAKE_C_FLAGS='-D__USE_MINGW_ANSI_STDIO -Wno-error=format' -DCMAKE_CXX_FLAGS='-D__USE_MINGW_ANSI_STDIO -Wno-error=format' &&

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [windows-latest]
         mode: [debug, release]
-        config-opt: [' ', --enable-thread-safety]
+        config-opt: [' ', --enable-thread-safety, --enable-thread-safety --enable-mcsat]
 
     name: ${{ matrix.os }}|${{ matrix.mode }}|${{ matrix.config-opt}}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -71,6 +71,7 @@ jobs:
         git clone https://github.com/ivmai/cudd.git &&
         cd cudd &&
         git checkout tags/cudd-3.0.0 &&
+        sed -i 's/\r$//' configure &&
         ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --disable-shared --enable-static --prefix=/tools/mcsat_deps &&
         make &&
         make install

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -41,14 +41,14 @@ jobs:
     - name: Building GMP
       shell: bash
       env:
-        CYGWIN: winsymlinks:native
+        CYGWIN: winsymlinks:native binmode
       run: pushd . && mkdir -p /tools && cd /tools && mkdir -p dynamic_gmp static_gmp && gmp_archive=gmp-6.3.0.tar.xz && (curl -fL --retry 5 --retry-delay 2 --connect-timeout 20 --max-time 600 https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz -o "$gmp_archive" || wget --tries=5 --timeout=20 -O "$gmp_archive" https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz || curl -fL --retry 5 --retry-delay 2 --connect-timeout 20 --max-time 600 https://mirrors.kernel.org/gnu/gmp/gmp-6.3.0.tar.xz -o "$gmp_archive" || wget --tries=5 --timeout=20 -O "$gmp_archive" https://mirrors.kernel.org/gnu/gmp/gmp-6.3.0.tar.xz || curl -fL --retry 5 --retry-delay 2 --connect-timeout 20 --max-time 600 https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz -o "$gmp_archive" || wget --tries=5 --timeout=20 -O "$gmp_archive" https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz) && tar xf "$gmp_archive" && cd gmp-6.3.0 && ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --enable-cxx --enable-shared --disable-static --prefix=/tools/dynamic_gmp && make && make install && make clean && ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --enable-cxx --enable-static --disable-shared --prefix=/tools/static_gmp && make && make install && popd
 
     - name: Building MCSAT Dependencies
       if: contains(matrix.config-opt, '--enable-mcsat')
       shell: bash
       env:
-        CYGWIN: winsymlinks:native
+        CYGWIN: winsymlinks:native binmode
       run: >-
         mkdir -p /tools/mcsat_deps &&
         git clone https://github.com/SRI-CSL/libpoly.git &&
@@ -65,7 +65,7 @@ jobs:
         sed -i 's/\r$//' configure &&
         find build-aux -type f -exec sed -i 's/\r$//' {} + &&
         chmod +x configure build-aux/* &&
-        ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --disable-shared --enable-static --disable-dependency-tracking --prefix=/tools/mcsat_deps &&
+        ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --disable-shared --enable-static --disable-dependency-tracking --disable-maintainer-mode --prefix=/tools/mcsat_deps &&
         test -f config.status && sed -i 's/\r$//' config.status || true &&
         test -f libtool && sed -i 's/\r$//' libtool || true &&
         make &&
@@ -75,7 +75,7 @@ jobs:
       if: "!contains(matrix.config-opt, '--enable-mcsat')"
       shell: bash
       env:
-        CYGWIN: winsymlinks:native
+        CYGWIN: winsymlinks:native binmode
       run: >-
         autoconf &&
         ./configure ${{ matrix.config-opt }} --host=x86_64-w64-mingw32 CPPFLAGS="-I/tools/dynamic_gmp/include" LDFLAGS="-L/tools/dynamic_gmp/lib" --with-static-gmp=/tools/static_gmp/lib/libgmp.a --with-static-gmp-include-dir=/tools/static_gmp/include &&
@@ -86,7 +86,7 @@ jobs:
       if: contains(matrix.config-opt, '--enable-mcsat')
       shell: bash
       env:
-        CYGWIN: winsymlinks:native
+        CYGWIN: winsymlinks:native binmode
       run: >-
         autoconf &&
         ./configure ${{ matrix.config-opt }} --host=x86_64-w64-mingw32 CPPFLAGS="-I/tools/dynamic_gmp/include -I/tools/mcsat_deps/include" LDFLAGS="-L/tools/dynamic_gmp/lib -L/tools/mcsat_deps/lib" --with-static-gmp=/tools/static_gmp/lib/libgmp.a --with-static-gmp-include-dir=/tools/static_gmp/include --with-static-libpoly=/tools/mcsat_deps/lib/libpoly.a --with-static-libpoly-include-dir=/tools/mcsat_deps/include &&
@@ -96,7 +96,7 @@ jobs:
     - name: Run Yices API Tests
       shell: bash
       env:
-        CYGWIN: winsymlinks:native
+        CYGWIN: winsymlinks:native binmode
       run: >-
         export PATH=/tools/dynamic_gmp/bin:/tools/static_gmp/bin:$PATH &&
         make OPTION=mingw64 MODE=${{ matrix.mode }} check-api &&

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -25,6 +25,7 @@ jobs:
         # Packages to install
         packages: |
           autoconf,
+          automake,
           cmake,
           coreutils,
           gperf,

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -61,7 +61,7 @@ jobs:
         git clone https://github.com/SRI-CSL/libpoly.git &&
         mkdir -p libpoly/build-mingw &&
         cd libpoly/build-mingw &&
-        cmake .. -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_INSTALL_PREFIX=/tools/mcsat_deps -DBUILD_SHARED_LIBS=OFF -DGMP_LIBRARY=/tools/static_gmp/lib/libgmp.a -DGMP_INCLUDE_DIR=/tools/static_gmp/include &&
+        cmake .. -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -DCMAKE_INSTALL_PREFIX=/tools/mcsat_deps -DBUILD_SHARED_LIBS=OFF -DGMP_LIBRARY=/tools/static_gmp/lib/libgmp.a -DGMP_INCLUDE_DIR=/tools/static_gmp/include -DCMAKE_C_FLAGS='-D__USE_MINGW_ANSI_STDIO -Wno-error=format' -DCMAKE_CXX_FLAGS='-D__USE_MINGW_ANSI_STDIO -Wno-error=format' &&
         make &&
         make install &&
         cd ../.. &&

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -66,6 +66,8 @@ jobs:
         find build-aux -type f -exec sed -i 's/\r$//' {} + &&
         chmod +x configure build-aux/* &&
         ./configure --host=x86_64-w64-mingw32 --build=i686-pc-cygwin --disable-shared --enable-static --disable-dependency-tracking --prefix=/tools/mcsat_deps &&
+        test -f config.status && sed -i 's/\r$//' config.status || true &&
+        test -f libtool && sed -i 's/\r$//' libtool || true &&
         make &&
         make install
 

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -29,6 +29,7 @@ jobs:
           cmake,
           coreutils,
           gperf,
+          libtool,
           m4,
           make,
           mingw64-x86_64-gcc-core,

--- a/src/api/yices_api.c
+++ b/src/api/yices_api.c
@@ -9216,7 +9216,7 @@ smt_status_t _o_yices_check_context_with_assumptions(context_t *ctx, const param
 }
 
 EXPORTED smt_status_t yices_check_context_with_assumptions(context_t *ctx, const param_t *params, uint32_t n, const term_t a[]) {
-  MT_PROTECT(smt_status_t, __yices_globals.lock, _o_yices_check_context_with_assumptions(ctx, params, n, a));
+  return _o_yices_check_context_with_assumptions(ctx, params, n, a);
 }
 
 /*

--- a/src/api/yices_api.c
+++ b/src/api/yices_api.c
@@ -9243,7 +9243,7 @@ static bool good_terms_for_check_with_model(uint32_t n, const term_t t[]) {
  *
  * This checks ctx /\ t[0] = val(mdl, t[0]) /\ .... /\ t[n-1] = val(mdl, t[n-1])
  */
-EXPORTED smt_status_t yices_check_context_with_model(context_t *ctx, const param_t *params, model_t* mdl, uint32_t n, const term_t t[]) {
+static smt_status_t _o_yices_check_context_with_model(context_t *ctx, const param_t *params, model_t* mdl, uint32_t n, const term_t t[]) {
   param_t default_params;
   smt_status_t stat;
 
@@ -9252,7 +9252,7 @@ EXPORTED smt_status_t yices_check_context_with_model(context_t *ctx, const param
     return YICES_STATUS_ERROR;
   }
 
-  if (! good_terms_for_check_with_model(n, t)) {
+  if (! _o_good_terms_for_check_with_model(n, t)) {
     // this sets the error code already (to VARIABLE_REQUIRED)
     // but Dejan created another error code that means the same thing here.
     set_error_code(MCSAT_ERROR_ASSUMPTION_TERM_NOT_SUPPORTED);
@@ -9308,6 +9308,10 @@ EXPORTED smt_status_t yices_check_context_with_model(context_t *ctx, const param
   return stat;
 }
 
+EXPORTED smt_status_t yices_check_context_with_model(context_t *ctx, const param_t *params, model_t* mdl, uint32_t n, const term_t t[]) {
+  MT_PROTECT(smt_status_t, __yices_globals.lock, _o_yices_check_context_with_model(ctx, params, mdl, n, t));
+}
+
 
 /*
  * Check context with model and hint
@@ -9319,7 +9323,7 @@ EXPORTED smt_status_t yices_check_context_with_model(context_t *ctx, const param
  *
  * This checks ctx /\ t[0] = val(mdl, t[0]) /\ .... /\ t[m-1] = val(mdl, t[m-1])
  */
-EXPORTED smt_status_t yices_check_context_with_model_and_hint(context_t *ctx, const param_t *params, model_t* mdl, uint32_t n, const term_t t[], uint32_t m) {
+static smt_status_t _o_yices_check_context_with_model_and_hint(context_t *ctx, const param_t *params, model_t* mdl, uint32_t n, const term_t t[], uint32_t m) {
 
   param_t default_params;
   smt_status_t stat;
@@ -9329,7 +9333,7 @@ EXPORTED smt_status_t yices_check_context_with_model_and_hint(context_t *ctx, co
     return YICES_STATUS_ERROR;
   }
 
-  if (! good_terms_for_check_with_model(n, t)) {
+  if (! _o_good_terms_for_check_with_model(n, t)) {
     // this sets the error code already (to VARIABLE_REQUIRED)
     // but Dejan created another error code that means the same thing here.
     set_error_code(MCSAT_ERROR_ASSUMPTION_TERM_NOT_SUPPORTED);
@@ -9385,6 +9389,10 @@ EXPORTED smt_status_t yices_check_context_with_model_and_hint(context_t *ctx, co
   }
 
   return stat;
+}
+
+EXPORTED smt_status_t yices_check_context_with_model_and_hint(context_t *ctx, const param_t *params, model_t* mdl, uint32_t n, const term_t t[], uint32_t m) {
+  MT_PROTECT(smt_status_t, __yices_globals.lock, _o_yices_check_context_with_model_and_hint(ctx, params, mdl, n, t, m));
 }
 
 /*

--- a/src/context/context.h
+++ b/src/context/context.h
@@ -144,13 +144,6 @@ extern bool context_has_simplex_solver(context_t *ctx);
 extern int32_t assert_formula(context_t *ctx, term_t f);
 
 /*
- * Lock-free version of assert_formula.
- * The caller must already own __yices_globals.lock.
- */
-extern int32_t _o_assert_formula(context_t *ctx, term_t f);
-
-
-/*
  * Assert all formulas f[0] ... f[n-1]
  * same return code as above.
  */

--- a/src/context/context.h
+++ b/src/context/context.h
@@ -143,6 +143,12 @@ extern bool context_has_simplex_solver(context_t *ctx);
  */
 extern int32_t assert_formula(context_t *ctx, term_t f);
 
+/*
+ * Lock-free version of assert_formula.
+ * The caller must already own __yices_globals.lock.
+ */
+extern int32_t _o_assert_formula(context_t *ctx, term_t f);
+
 
 /*
  * Assert all formulas f[0] ... f[n-1]

--- a/src/context/context_solver.c
+++ b/src/context/context_solver.c
@@ -793,7 +793,7 @@ smt_status_t check_context_with_term_assumptions(context_t *ctx, const param_t *
       term_t implication = mk_implies(&tm, b, a[i]);
 
       int_hmap_add(&label_map, b, a[i]);
-      code = assert_formula(ctx, implication);
+      code = _o_assert_formula(ctx, implication);
       if (code < 0) {
         if (error != NULL) {
           *error = code;

--- a/src/context/context_solver.c
+++ b/src/context/context_solver.c
@@ -44,6 +44,7 @@
 #include "utils/int_hash_sets.h"
 
 #include "api/yices_globals.h"
+#include "api/yices_api_lock_free.h"
 #include "mt/thread_macros.h"
 
 

--- a/src/context/context_solver.c
+++ b/src/context/context_solver.c
@@ -716,44 +716,13 @@ static void cache_unsat_core(context_t *ctx, const ivector_t *core) {
 }
 
 /*
- * Check under assumptions given as terms.
- * - if MCSAT is enabled, this uses temporary labels + model interpolation.
- * - otherwise terms are converted to literals and handled by the CDCL(T) path.
- *
- * Preconditions:
- * - context status must be IDLE.
+ * MCSAT variant of check_context_with_term_assumptions.
+ * Caller must hold __yices_globals.lock.
  */
-smt_status_t check_context_with_term_assumptions(context_t *ctx, const param_t *params, uint32_t n, const term_t *a, int32_t *error) {
+static smt_status_t _o_check_context_with_term_assumptions_mcsat(context_t *ctx, const param_t *params, uint32_t n, const term_t *a, int32_t *error) {
   smt_status_t stat;
   ivector_t assumptions;
   uint32_t i;
-
-  if (error != NULL) {
-    *error = CTX_NO_ERROR;
-  }
-
-  context_invalidate_unsat_core_cache(ctx);
-
-  if (ctx->mcsat == NULL) {
-    literal_t l;
-
-    init_ivector(&assumptions, n);
-    for (i=0; i<n; i++) {
-      l = context_add_assumption(ctx, a[i]);
-      if (l < 0) {
-        if (error != NULL) {
-          *error = l;
-        }
-        delete_ivector(&assumptions);
-        return YICES_STATUS_ERROR;
-      }
-      ivector_push(&assumptions, l);
-    }
-
-    stat = check_context_with_assumptions(ctx, params, n, assumptions.data);
-    delete_ivector(&assumptions);
-    return stat;
-  }
 
   /*
    * MCSAT: create fresh labels b_i, assert (b_i => a_i), then solve with model b_i=true.
@@ -837,6 +806,52 @@ smt_status_t check_context_with_term_assumptions(context_t *ctx, const param_t *
 
     return stat;
   }
+}
+
+static smt_status_t check_context_with_term_assumptions_mcsat(context_t *ctx, const param_t *params, uint32_t n, const term_t *a, int32_t *error) {
+  MT_PROTECT(smt_status_t, __yices_globals.lock, _o_check_context_with_term_assumptions_mcsat(ctx, params, n, a, error));
+}
+
+/*
+ * Check under assumptions given as terms.
+ * - if MCSAT is enabled, this uses temporary labels + model interpolation.
+ * - otherwise terms are converted to literals and handled by the CDCL(T) path.
+ *
+ * Preconditions:
+ * - context status must be IDLE.
+ */
+smt_status_t check_context_with_term_assumptions(context_t *ctx, const param_t *params, uint32_t n, const term_t *a, int32_t *error) {
+  if (error != NULL) {
+    *error = CTX_NO_ERROR;
+  }
+
+  context_invalidate_unsat_core_cache(ctx);
+
+  if (ctx->mcsat == NULL) {
+    smt_status_t stat;
+    ivector_t assumptions;
+    uint32_t i;
+    literal_t l;
+
+    init_ivector(&assumptions, n);
+    for (i=0; i<n; i++) {
+      l = context_add_assumption(ctx, a[i]);
+      if (l < 0) {
+        if (error != NULL) {
+          *error = l;
+        }
+        delete_ivector(&assumptions);
+        return YICES_STATUS_ERROR;
+      }
+      ivector_push(&assumptions, l);
+    }
+
+    stat = check_context_with_assumptions(ctx, params, n, assumptions.data);
+    delete_ivector(&assumptions);
+    return stat;
+  }
+
+  return check_context_with_term_assumptions_mcsat(ctx, params, n, a, error);
 }
 
 /*

--- a/src/mcsat/bv/bv_explainer.c
+++ b/src/mcsat/bv/bv_explainer.c
@@ -39,6 +39,7 @@
 
 #include "yices.h"
 #include "api/yices_api_lock_free.h"
+#include "context/context.h"
 #include <inttypes.h>
 
 void bv_subexplainer_construct(bv_subexplainer_t* exp, const char* name, plugin_context_t* ctx, watch_list_manager_t* wlm, bv_evaluator_t* eval) {
@@ -175,7 +176,7 @@ void bv_explainer_check_conflict(bv_explainer_t* exp, const ivector_t* conflict)
   for (i = 0; i < conflict->size; ++ i) {
     _o_yices_assert_formula(ctx, conflict->data[i]);
   }
-  smt_status_t result = yices_check_context(ctx, NULL);
+  smt_status_t result = check_context(ctx, NULL);
   (void) result;
   assert(result == YICES_STATUS_UNSAT);
   _o_yices_free_context(ctx);
@@ -283,4 +284,3 @@ term_t bv_explainer_explain_propagation(bv_explainer_t* exp, variable_t x, const
 
   return subst;
 }
-

--- a/src/mcsat/conflict.c
+++ b/src/mcsat/conflict.c
@@ -27,6 +27,7 @@
 
 #include "io/term_printer.h"
 #include "mcsat/tracing.h"
+#include "context/context.h"
 
 #include "yices.h"
 #include "api/yices_api_lock_free.h"
@@ -35,8 +36,7 @@
 #define CONFLICT_DEFAULT_ELEMENT_SIZE 100
 
 void conflict_check(conflict_t* conflict) {
-  ctx_config_t* config = yices_new_config();
-  context_t* ctx = _o_yices_new_context(config);
+  context_t* ctx = _o_yices_new_context(NULL);
   uint32_t i;
   const ivector_t* literals = &conflict->disjuncts.element_list;
   for (i = 0; i < literals->size; ++i) {
@@ -50,11 +50,10 @@ void conflict_check(conflict_t* conflict) {
       return;
     }
   }
-  smt_status_t result = yices_check_context(ctx, NULL);
+  smt_status_t result = check_context(ctx, NULL);
   (void) result;
   assert(result == YICES_STATUS_UNSAT);
   _o_yices_free_context(ctx);
-  yices_free_config(config);
 }
 
 /**

--- a/src/mcsat/solver.c
+++ b/src/mcsat/solver.c
@@ -57,6 +57,7 @@
 #include "io/model_printer.h"
 
 #include "yices.h"
+#include "api/yices_api_lock_free.h"
 #include <inttypes.h>
 #include <math.h>
 
@@ -1874,31 +1875,31 @@ uint32_t mcsat_get_lemma_weight(mcsat_solver_t* mcsat, const ivector_t* lemma, l
 /** Check propagation with Yices: reasons => x = subst */
 static
 void propagation_check(const ivector_t* reasons, term_t x, term_t subst) {
-  ctx_config_t* config = yices_new_config();
-   context_t* ctx = yices_new_context(config);
+   context_t* ctx = _o_yices_new_context(NULL);
    uint32_t i;
    for (i = 0; i < reasons->size; ++i) {
      term_t literal = reasons->data[i];
-     int32_t ret = yices_assert_formula(ctx, literal);
+     int32_t ret = _o_yices_assert_formula(ctx, literal);
      if (ret != 0) {
        // unsupported by regular yices
        fprintf(stderr, "skipping propagation (ret 1)\n");
        yices_print_error(stderr);
+       _o_yices_free_context(ctx);
        return;
      }
    }
-   term_t eq = yices_eq(x, subst);
-   int32_t ret = yices_assert_formula(ctx, opposite_term(eq));
+   term_t eq = _o_yices_eq(x, subst);
+   int32_t ret = _o_yices_assert_formula(ctx, opposite_term(eq));
    if (ret != 0) {
      fprintf(stderr, "skipping propagation (ret 2)\n");
      yices_print_error(stderr);
+     _o_yices_free_context(ctx);
      return;
    }
-   smt_status_t result = yices_check_context(ctx, NULL);
+   smt_status_t result = check_context(ctx, NULL);
    (void) result;
    assert(result == YICES_STATUS_UNSAT);
-   yices_free_context(ctx);
-   yices_free_config(config);
+   _o_yices_free_context(ctx);
 }
 
 static

--- a/tests/api/test_cdcl_assumptions_lock_reentry.c
+++ b/tests/api/test_cdcl_assumptions_lock_reentry.c
@@ -6,10 +6,15 @@
  * to take the same global lock again.
  */
 
-#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <signal.h>
 #include <unistd.h>
+#endif
 
 #include <yices.h>
 
@@ -19,11 +24,67 @@ static void fail(const char *msg) {
   exit(2);
 }
 
+#if defined(_WIN32)
+static HANDLE watchdog_stop_event = NULL;
+static HANDLE watchdog_thread = NULL;
+
+static DWORD WINAPI watchdog_main(LPVOID arg) {
+  HANDLE stop_event = (HANDLE) arg;
+  DWORD status = WaitForSingleObject(stop_event, 15000);
+  if (status == WAIT_TIMEOUT) {
+    fprintf(stderr, "timeout: possible deadlock\n");
+    fflush(stderr);
+    ExitProcess(3);
+  }
+  return 0;
+}
+
+static void start_deadlock_watchdog(void) {
+  watchdog_stop_event = CreateEvent(NULL, TRUE, FALSE, NULL);
+  if (watchdog_stop_event == NULL) {
+    fprintf(stderr, "failed to create watchdog stop event\n");
+    exit(2);
+  }
+
+  watchdog_thread = CreateThread(NULL, 0, watchdog_main, watchdog_stop_event, 0, NULL);
+  if (watchdog_thread == NULL) {
+    CloseHandle(watchdog_stop_event);
+    watchdog_stop_event = NULL;
+    fprintf(stderr, "failed to create watchdog thread\n");
+    exit(2);
+  }
+}
+
+static void stop_deadlock_watchdog(void) {
+  if (watchdog_stop_event != NULL) {
+    SetEvent(watchdog_stop_event);
+  }
+  if (watchdog_thread != NULL) {
+    WaitForSingleObject(watchdog_thread, INFINITE);
+    CloseHandle(watchdog_thread);
+    watchdog_thread = NULL;
+  }
+  if (watchdog_stop_event != NULL) {
+    CloseHandle(watchdog_stop_event);
+    watchdog_stop_event = NULL;
+  }
+}
+#else
 static void on_alarm(int sig) {
   (void) sig;
   fprintf(stderr, "timeout: possible deadlock\n");
   exit(3);
 }
+
+static void start_deadlock_watchdog(void) {
+  signal(SIGALRM, on_alarm);
+  alarm(15);
+}
+
+static void stop_deadlock_watchdog(void) {
+  alarm(0);
+}
+#endif
 
 static context_t *make_cdclt_context(void) {
   ctx_config_t *config;
@@ -84,10 +145,9 @@ static void test_cdclt_check_with_assumptions_no_deadlock(void) {
 int main(void) {
   yices_init();
 
-  signal(SIGALRM, on_alarm);
-  alarm(15);
+  start_deadlock_watchdog();
   test_cdclt_check_with_assumptions_no_deadlock();
-  alarm(0);
+  stop_deadlock_watchdog();
 
   yices_exit();
   return 0;

--- a/tests/api/test_cdcl_assumptions_lock_reentry.c
+++ b/tests/api/test_cdcl_assumptions_lock_reentry.c
@@ -1,0 +1,94 @@
+/*
+ * Regression test for lock reentry in CDCL(T) check-with-assumptions path.
+ *
+ * Under THREAD_SAFE pre-fix code, yices_check_context_with_assumptions held the
+ * global lock, then CDCL(T) solving could reach egraph_final_check, which tried
+ * to take the same global lock again.
+ */
+
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <yices.h>
+
+static void fail(const char *msg) {
+  fprintf(stderr, "%s\n", msg);
+  yices_print_error(stderr);
+  exit(2);
+}
+
+static void on_alarm(int sig) {
+  (void) sig;
+  fprintf(stderr, "timeout: possible deadlock\n");
+  exit(3);
+}
+
+static context_t *make_cdclt_context(void) {
+  ctx_config_t *config;
+  context_t *context;
+  int32_t code;
+
+  config = yices_new_config();
+  code = yices_default_config_for_logic(config, "QF_UF");
+  if (code < 0) {
+    yices_free_config(config);
+    return NULL;
+  }
+
+  context = yices_new_context(config);
+  yices_free_config(config);
+  return context;
+}
+
+static void test_cdclt_check_with_assumptions_no_deadlock(void) {
+  context_t *ctx;
+  type_t u_ty;
+  term_t a, b;
+  term_t eq_ab;
+  term_t assumptions[1];
+  smt_status_t status;
+  int32_t code;
+
+  ctx = make_cdclt_context();
+  if (ctx == NULL) {
+    fail("failed to create CDCL(T) context");
+  }
+
+  u_ty = yices_new_uninterpreted_type();
+  a = yices_new_uninterpreted_term(u_ty);
+  b = yices_new_uninterpreted_term(u_ty);
+  eq_ab = yices_eq(a, b);
+
+  /*
+   * SAT EUF instance with an assumption.
+   * This exercises the CDCL(T) final-check path through egraph_final_check.
+   */
+  code = yices_assert_formula(ctx, eq_ab);
+  if (code < 0) {
+    yices_free_context(ctx);
+    fail("yices_assert_formula(eq_ab) failed");
+  }
+
+  assumptions[0] = eq_ab;
+  status = yices_check_context_with_assumptions(ctx, NULL, 1, assumptions);
+  if (status != YICES_STATUS_SAT) {
+    yices_free_context(ctx);
+    fail("expected SAT from yices_check_context_with_assumptions");
+  }
+
+  yices_free_context(ctx);
+}
+
+int main(void) {
+  yices_init();
+
+  signal(SIGALRM, on_alarm);
+  alarm(15);
+  test_cdclt_check_with_assumptions_no_deadlock();
+  alarm(0);
+
+  yices_exit();
+  return 0;
+}

--- a/tests/api/test_mcsat_trace_lock_reentry.c
+++ b/tests/api/test_mcsat_trace_lock_reentry.c
@@ -6,11 +6,16 @@
  * That caused deadlock.
  */
 
-#include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <signal.h>
 #include <unistd.h>
+#endif
 
 #include <yices.h>
 
@@ -20,11 +25,67 @@ static void fail(const char *msg) {
   exit(2);
 }
 
+#if defined(_WIN32)
+static HANDLE watchdog_stop_event = NULL;
+static HANDLE watchdog_thread = NULL;
+
+static DWORD WINAPI watchdog_main(LPVOID arg) {
+  HANDLE stop_event = (HANDLE) arg;
+  DWORD status = WaitForSingleObject(stop_event, 15000);
+  if (status == WAIT_TIMEOUT) {
+    fprintf(stderr, "timeout: possible deadlock\n");
+    fflush(stderr);
+    ExitProcess(3);
+  }
+  return 0;
+}
+
+static void start_deadlock_watchdog(void) {
+  watchdog_stop_event = CreateEvent(NULL, TRUE, FALSE, NULL);
+  if (watchdog_stop_event == NULL) {
+    fprintf(stderr, "failed to create watchdog stop event\n");
+    exit(2);
+  }
+
+  watchdog_thread = CreateThread(NULL, 0, watchdog_main, watchdog_stop_event, 0, NULL);
+  if (watchdog_thread == NULL) {
+    CloseHandle(watchdog_stop_event);
+    watchdog_stop_event = NULL;
+    fprintf(stderr, "failed to create watchdog thread\n");
+    exit(2);
+  }
+}
+
+static void stop_deadlock_watchdog(void) {
+  if (watchdog_stop_event != NULL) {
+    SetEvent(watchdog_stop_event);
+  }
+  if (watchdog_thread != NULL) {
+    WaitForSingleObject(watchdog_thread, INFINITE);
+    CloseHandle(watchdog_thread);
+    watchdog_thread = NULL;
+  }
+  if (watchdog_stop_event != NULL) {
+    CloseHandle(watchdog_stop_event);
+    watchdog_stop_event = NULL;
+  }
+}
+#else
 static void on_alarm(int sig) {
   (void) sig;
   fprintf(stderr, "timeout: possible deadlock\n");
   exit(3);
 }
+
+static void start_deadlock_watchdog(void) {
+  signal(SIGALRM, on_alarm);
+  alarm(15);
+}
+
+static void stop_deadlock_watchdog(void) {
+  alarm(0);
+}
+#endif
 
 static context_t *make_mcsat_context_with_trace(const char *logic, const char *trace_tags) {
   ctx_config_t *config;
@@ -163,13 +224,12 @@ int main(void) {
 
   yices_init();
 
-  signal(SIGALRM, on_alarm);
-  alarm(15);
+  start_deadlock_watchdog();
 
   test_mcsat_propagation_check_trace();
   test_mcsat_bv_conflict_trace_issue145();
 
-  alarm(0);
+  stop_deadlock_watchdog();
   yices_exit();
   return 0;
 }

--- a/tests/api/test_mcsat_trace_lock_reentry.c
+++ b/tests/api/test_mcsat_trace_lock_reentry.c
@@ -1,0 +1,175 @@
+/*
+ * Regression test for MCSAT trace checks under THREAD_SAFE builds.
+ *
+ * Before the lock-free trace-check fix, these traces could re-enter lock-taking
+ * API calls while the global lock was already held by yices_check_context.
+ * That caused deadlock.
+ */
+
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <yices.h>
+
+static void fail(const char *msg) {
+  fprintf(stderr, "%s\n", msg);
+  yices_print_error(stderr);
+  exit(2);
+}
+
+static void on_alarm(int sig) {
+  (void) sig;
+  fprintf(stderr, "timeout: possible deadlock\n");
+  exit(3);
+}
+
+static context_t *make_mcsat_context_with_trace(const char *logic, const char *trace_tags) {
+  ctx_config_t *config;
+  context_t *context;
+  int32_t code;
+
+  config = yices_new_config();
+  if (logic != NULL) {
+    code = yices_default_config_for_logic(config, logic);
+    if (code < 0) {
+      yices_free_config(config);
+      return NULL;
+    }
+  }
+  code = yices_set_config(config, "solver-type", "mcsat");
+  if (code < 0) {
+    yices_free_config(config);
+    return NULL;
+  }
+  code = yices_set_config(config, "trace", trace_tags);
+  if (code < 0) {
+    yices_free_config(config);
+    return NULL;
+  }
+
+  context = yices_new_context(config);
+  yices_free_config(config);
+  return context;
+}
+
+/*
+ * Trigger paths:
+ * yices_check_context -> mcsat solve -> (trace) conflict_check(...)
+ * yices_check_context -> mcsat solve -> BV plugin conflict explanation
+ * -> (trace) bv_explainer_check_conflict(...)
+ *
+ * Formula adapted from tests/regress/mcsat/bv/issue145.smt2.
+ */
+static void test_mcsat_bv_conflict_trace_issue145(void) {
+  context_t *ctx;
+  type_t bv5, bv4;
+  term_t x, y;
+  term_t e3, e4, e5, e8, e11, e14, e18;
+  smt_status_t status;
+  int32_t code;
+
+  ctx = make_mcsat_context_with_trace("QF_BV", "mcsat::conflict::check,mcsat::bv::conflict::check");
+  if (ctx == NULL) {
+    fail("failed to create mcsat context (bv conflict trace)");
+  }
+
+  bv5 = yices_bv_type(5);
+  bv4 = yices_bv_type(4);
+  x = yices_new_uninterpreted_term(bv5);
+  y = yices_new_uninterpreted_term(bv4);
+
+  e3 = yices_bvsrem(yices_sign_extend(y, 1), x);
+  e4 = yices_bvsub(e3, yices_bvconst_uint32(5, 0));
+  e5 = yices_bvgt_atom(e3, yices_zero_extend(y, 1));
+  e8 = yices_bvge_atom(x, e4);
+  e11 = yices_ite(e5, e5, e8);
+  e14 = yices_implies(e11, yices_false());
+  e18 = yices_and2(e14, yices_not(yices_bveq_atom(x, yices_bvconst_uint32(5, 0))));
+
+  code = yices_assert_formula(ctx, e18);
+  if (code < 0) {
+    yices_free_context(ctx);
+    fail("yices_assert_formula(issue145) failed");
+  }
+
+  status = yices_check_context(ctx, NULL);
+  if (status != YICES_STATUS_UNSAT) {
+    yices_free_context(ctx);
+    fail("expected UNSAT from issue145 trace test");
+  }
+
+  yices_free_context(ctx);
+}
+
+/*
+ * Trigger path:
+ * yices_check_context -> mcsat propagate (non-bool plugin)
+ * -> (trace) propagation_check(...)
+ */
+static void test_mcsat_propagation_check_trace(void) {
+  context_t *ctx;
+  term_t x, x4, x_le_0, x_or_0, abs_x4, sub_t, sq_t, mul_t, arbitrary;
+  term_t one, r1;
+  term_t distinct_args[2];
+  smt_status_t status;
+  int32_t code;
+
+  ctx = make_mcsat_context_with_trace("QF_NIA", "mcsat::propagation::check");
+  if (ctx == NULL) {
+    fail("failed to create mcsat context (propagation trace)");
+  }
+
+  /*
+   * Non-linear arithmetic UNSAT instance adapted from nra_plugin_explain.c.
+   * This tends to force non-Boolean plugin reasoning/propagation.
+   */
+  x = yices_new_uninterpreted_term(yices_int_type());
+  x4 = yices_power(x, 4);
+  x_le_0 = yices_arith_leq_atom(x, yices_zero());
+  x_or_0 = yices_ite(x_le_0, x, yices_zero());
+  abs_x4 = yices_abs(x4);
+  sub_t = yices_sub(x4, x_or_0);
+  sq_t = yices_square(sub_t);
+  mul_t = yices_mul(abs_x4, sq_t);
+  arbitrary = yices_mul(x_or_0, mul_t);
+
+  one = yices_int32(1);
+  r1 = yices_ite(yices_eq(yices_zero(), arbitrary), one, yices_idiv(arbitrary, arbitrary));
+  distinct_args[0] = r1;
+  distinct_args[1] = one;
+
+  code = yices_assert_formula(ctx, yices_distinct(2, distinct_args));
+  if (code < 0) {
+    yices_free_context(ctx);
+    fail("yices_assert_formula(distinct) failed");
+  }
+
+  status = yices_check_context(ctx, NULL);
+  if (status != YICES_STATUS_UNSAT) {
+    yices_free_context(ctx);
+    fail("expected UNSAT from propagation trace test");
+  }
+
+  yices_free_context(ctx);
+}
+
+int main(void) {
+  if (!yices_has_mcsat()) {
+    return 1; // skipped
+  }
+
+  yices_init();
+
+  signal(SIGALRM, on_alarm);
+  alarm(15);
+
+  test_mcsat_propagation_check_trace();
+  test_mcsat_bv_conflict_trace_issue145();
+
+  alarm(0);
+  yices_exit();
+  return 0;
+}

--- a/tests/api/test_mcsat_unsat_core_assumptions.c
+++ b/tests/api/test_mcsat_unsat_core_assumptions.c
@@ -1,0 +1,111 @@
+/*
+ * Test unsat core construction with assumptions in an MCSAT context.
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <yices.h>
+
+static void fail(const char *msg) {
+  fprintf(stderr, "%s\n", msg);
+  exit(2);
+}
+
+static context_t *make_mcsat_context(void) {
+  ctx_config_t *config;
+  context_t *context;
+  int32_t code;
+
+  config = yices_new_config();
+  code = yices_set_config(config, "solver-type", "mcsat");
+  if (code < 0) goto error;
+
+  context = yices_new_context(config);
+  if (context == NULL) goto error;
+
+  yices_free_config(config);
+  return context;
+
+ error:
+  yices_print_error(stderr);
+  yices_free_config(config);
+  return NULL;
+}
+
+static bool has_term(const term_vector_t *v, term_t t) {
+  uint32_t i;
+
+  for (i = 0; i < v->size; i++) {
+    if (v->data[i] == t) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static void test_unsat_core_with_assumptions_mcsat(void) {
+  context_t *ctx;
+  type_t bool_ty;
+  term_t p, q, c;
+  term_t assumptions[2];
+  term_vector_t core;
+  smt_status_t status;
+  int32_t code;
+
+  ctx = make_mcsat_context();
+  if (ctx == NULL) {
+    fail("failed to create mcsat context");
+  }
+
+  bool_ty = yices_bool_type();
+  p = yices_new_uninterpreted_term(bool_ty);
+  q = yices_new_uninterpreted_term(bool_ty);
+
+  /*
+   * Base constraint: not (p and q), encoded as (or (not p) (not q)).
+   * With assumptions p and q, the context is UNSAT and both assumptions
+   * are required.
+   */
+  c = yices_or2(yices_not(p), yices_not(q));
+  code = yices_assert_formula(ctx, c);
+  if (code < 0) {
+    yices_print_error(stderr);
+    fail("yices_assert_formula failed");
+  }
+
+  assumptions[0] = p;
+  assumptions[1] = q;
+
+  status = yices_check_context_with_assumptions(ctx, NULL, 2, assumptions);
+  if (status != YICES_STATUS_UNSAT) {
+    yices_print_error(stderr);
+    fail("expected UNSAT from yices_check_context_with_assumptions");
+  }
+
+  yices_init_term_vector(&core);
+  code = yices_get_unsat_core(ctx, &core);
+  if (code < 0) {
+    yices_print_error(stderr);
+    fail("yices_get_unsat_core failed");
+  }
+  if (core.size != 2 || !has_term(&core, p) || !has_term(&core, q)) {
+    fail("unexpected unsat core content");
+  }
+  yices_delete_term_vector(&core);
+
+  yices_free_context(ctx);
+}
+
+int main(void) {
+  if (! yices_has_mcsat()) {
+    return 1; // skipped
+  }
+
+  yices_init();
+  test_unsat_core_with_assumptions_mcsat();
+  yices_exit();
+
+  return 0;
+}

--- a/tests/regress/check.sh
+++ b/tests/regress/check.sh
@@ -106,6 +106,11 @@ then
     REGRESS_FILTER="."
 fi
 
+if [[ -z "$REGRESS_EXCLUDE_FILTER" ]];
+then
+    REGRESS_EXCLUDE_FILTER="^$"
+fi
+
 #
 # Check if MCSAT is supported
 #
@@ -120,7 +125,7 @@ fi
 if [ -z "$all_tests" ] ; then
     all_tests=$(
     find "$regress_dir" -name '*.smt' -or -name '*.smt2' -or -name '*.ys' |
-      grep $REGRESS_FILTER | grep $MCSAT_FILTER |
+      grep $REGRESS_FILTER | grep $MCSAT_FILTER | grep -v "$REGRESS_EXCLUDE_FILTER" |
       sort
     )
 fi


### PR DESCRIPTION
This branch fixes lock reentry issues that occur when Yices is built with both `--enable-mcsat` and `--enable-thread-safety`, specifically in:
- MCSAT assumptions / unsat-core flow
- MCSAT trace/debug check helpers that re-entered lock-taking API calls
- CDCL(T) assumptions / e-graph final check(also present without the --enable-mcsat configure option)

## What Changed

### 1) MCSAT assumptions / unsat-core lock recursion fix
- In MCSAT assumptions flow, switched assertion to lock-free entrypoint:
  - `assert_formula(...)` -> `_o_assert_formula(...)`
- This prevents recursive acquisition of the global API lock in lock-protected assumptions/unsat-core execution.

**Files**
- `src/context/context.h`
- `src/context/context_solver.c`

### 2) MCSAT trace/debug helpers now use lock-free/internal entrypoints
- Converted trace-only check helpers to avoid lock-taking API calls:
  - `propagation_check` in `src/mcsat/solver.c`
  - `conflict_check` in `src/mcsat/conflict.c`
  - `bv_explainer_check_conflict` in `src/mcsat/bv/bv_explainer.c`
- Key call replacements:
  - `yices_new_context` -> `_o_yices_new_context`
  - `yices_assert_formula` -> `_o_yices_assert_formula`
  - `yices_eq` -> `_o_yices_eq`
  - `yices_check_context` -> `check_context`
  - `yices_free_context` -> `_o_yices_free_context`
- Removed unnecessary temporary config allocation in trace checks (`_o_yices_new_context(NULL)`).

**Files**
- `src/mcsat/solver.c`
- `src/mcsat/conflict.c`
- `src/mcsat/bv/bv_explainer.c`

### 3) `check_with_assumptions` lock placement adjusted to avoid CDCL(T) double-grab
- `yices_check_context_with_assumptions` no longer takes a top-level global lock wrapper.
- `check_context_with_term_assumptions` was refactored so:
  - CDCL(T) assumptions solving continues through existing path (no extra global lock added there).
  - MCSAT assumptions path takes the global lock in the MCSAT-specific helper around the push/check/pop transaction.
- This avoids CDCL(T) lock re-entry via `... -> smt_final_check -> egraph_final_check`.

**Files**
- `src/api/yices_api.c`
- `src/context/context_solver.c`

### 4) CI/build cleanup for lock-free symbol declaration
- Removed redundant `_o_assert_formula` declaration from `context.h`.
- Included `api/yices_api_lock_free.h` in `context_solver.c` to use canonical declaration.
- Fixes `-Werror=redundant-decls` CI failure.

**Files**
- `src/context/context.h`
- `src/context/context_solver.c`

## Tests Added

- `tests/api/test_mcsat_unsat_core_assumptions.c`  
  Regression for MCSAT unsat-core via `yices_check_context_with_assumptions`.

- `tests/api/test_cdcl_assumptions_lock_reentry.c`  
  Regression for CDCL(T) assumptions path lock re-entry/deadlock risk.

## Outcome

With these 4 commits, branch behavior is aligned with mixed `--enable-mcsat + --enable-thread-safety` builds by eliminating known global-lock recursion hotspots in:
- MCSAT assumptions/unsat-core flow
- MCSAT trace/debug check helpers
- CDCL(T) check-with-assumptions final-check interaction
- CI build declaration consistency
