### PR TITLE
Disable a few MCSAT tracing checks in THREAD_SAFE builds (lock reentry)

### DIFF
--- a/src/mcsat/bv/bv_explainer.c
+++ b/src/mcsat/bv/bv_explainer.c
@@ -171,6 +171,11 @@ void bv_explainer_normalize_conflict(bv_explainer_t* exp, ivector_t* conflict_ou
 }
 
 void bv_explainer_check_conflict(bv_explainer_t* exp, const ivector_t* conflict) {
+#ifdef THREAD_SAFE
+  (void) exp;
+  (void) conflict;
+  return;
+#else
   context_t* ctx = _o_yices_new_context(NULL);
   uint32_t i;
   for (i = 0; i < conflict->size; ++ i) {
@@ -180,6 +185,7 @@ void bv_explainer_check_conflict(bv_explainer_t* exp, const ivector_t* conflict)
   (void) result;
   assert(result == YICES_STATUS_UNSAT);
   _o_yices_free_context(ctx);
+#endif
 }
 
 void print_counters(bv_explainer_t* exp){

--- a/src/mcsat/bv/bv_utils.h
+++ b/src/mcsat/bv/bv_utils.h
@@ -466,6 +466,12 @@ uint32_t fix_htbl_index(term_t* htbl, uint32_t size, term_t key){
 
 static inline
 bool check_rewrite(plugin_context_t* ctx, term_t old, term_t t){
+#ifdef THREAD_SAFE
+  (void) ctx;
+  (void) old;
+  (void) t;
+  return true;
+#else
   if (t == old) return true;
   term_manager_t* tm   = ctx->tm;
   context_t* yctx      = _o_yices_new_context(NULL);
@@ -482,6 +488,7 @@ bool check_rewrite(plugin_context_t* ctx, term_t old, term_t t){
   }
   _o_yices_free_context(yctx);
   return result;
+#endif
 }
 
 #endif

--- a/src/mcsat/conflict.c
+++ b/src/mcsat/conflict.c
@@ -36,6 +36,10 @@
 #define CONFLICT_DEFAULT_ELEMENT_SIZE 100
 
 void conflict_check(conflict_t* conflict) {
+#ifdef THREAD_SAFE
+  (void) conflict;
+  return;
+#else
   context_t* ctx = _o_yices_new_context(NULL);
   uint32_t i;
   const ivector_t* literals = &conflict->disjuncts.element_list;
@@ -54,6 +58,7 @@ void conflict_check(conflict_t* conflict) {
   (void) result;
   assert(result == YICES_STATUS_UNSAT);
   _o_yices_free_context(ctx);
+#endif
 }
 
 /**

--- a/src/mcsat/solver.c
+++ b/src/mcsat/solver.c
@@ -1875,6 +1875,12 @@ uint32_t mcsat_get_lemma_weight(mcsat_solver_t* mcsat, const ivector_t* lemma, l
 /** Check propagation with Yices: reasons => x = subst */
 static
 void propagation_check(const ivector_t* reasons, term_t x, term_t subst) {
+#ifdef THREAD_SAFE
+   (void) reasons;
+   (void) x;
+   (void) subst;
+   return;
+#else
    context_t* ctx = _o_yices_new_context(NULL);
    uint32_t i;
    for (i = 0; i < reasons->size; ++i) {
@@ -1900,6 +1906,7 @@ void propagation_check(const ivector_t* reasons, term_t x, term_t subst) {
    (void) result;
    assert(result == YICES_STATUS_UNSAT);
    _o_yices_free_context(ctx);
+#endif
 }
 
 static


### PR DESCRIPTION
This PR prevents lock re-entry hazards in `THREAD_SAFE` builds by disabling MCSAT diagnostic self-check paths that call back into CDCL(T).

When Yices is built with both `--enable-thread-safety` and `--enable-mcsat`, these diagnostics can run while the global API lock is already held by MCSAT solving, then invoke CDCL(T) checks that may try to acquire the same lock again.

## What changed

In `THREAD_SAFE` builds only, the following diagnostic/debug checks are turned into no-ops:

- `propagation_check(...)` in `src/mcsat/solver.c`
- `conflict_check(...)` in `src/mcsat/conflict.c`
- `bv_explainer_check_conflict(...)` in `src/mcsat/bv/bv_explainer.c`
- `check_rewrite(...)` in `src/mcsat/bv/bv_utils.h` (debug helper under `#ifndef NDEBUG`)

Implementation pattern:
- `#ifdef THREAD_SAFE` => return immediately (with `(void)` casts for unused args)
- `#else` => keep existing diagnostic behavior unchanged

## Scope and rationale

- This is a minimal safety fix.
- It does **not** change normal solving logic.
- It only disables internal validation/tracing checks that recurse into CDCL(T) from MCSAT.

One MCSAT/BV path into Yices is intentionally unchanged:

- Functional BV-core extraction in `full_bv_sat` is intentionally left untouched:
- `bb_sat_solver_solve_and_get_core(...)` in `src/mcsat/bv/explain/full_bv_sat.c`
- Calls `_o_yices_check_context_with_assumptions(...)` on an internal temporary context

This path should be safe because:

- The temporary context is created as `QF_BV` + `CTX_ARCH_BV` (`new_yices_bv_context`), i.e., no egraph.
- Without egraph, it does not reach `egraph_final_check` (the CDCL(T) site that grabs `__yices_globals.lock`).
- It uses the lock-free `_o_...` entrypoint (not the exported lock-taking wrapper).
- The temporary context is not MCSAT, so `call_mcsat_solver` lock wrapper is not involved.

So this path does not introduce the same nested global-lock acquisition risk as the four diagnostic paths above.
