### PR TITLE
portfolio: fix sat/unsat detection, race conditions, and path resolution

### DIFF
--- a/utils/yices2_parallel.py
+++ b/utils/yices2_parallel.py
@@ -23,62 +23,60 @@ import threading
 import sys
 import os
 import signal
+import shutil
 import time
 import argparse
 import random
 from typing import List
 
+_active_solver = None
+
 def _global_signal_handler(signum, frame):
-    """Global signal handler for the main process"""
     if signum == signal.SIGINT:
         print("\nReceived Ctrl+C, shutting down gracefully...", file=sys.stderr)
     else:
         print(f"\nReceived signal {signum}, shutting down gracefully...", file=sys.stderr)
-    
-    # Clean up any running threads
-    if hasattr(_global_signal_handler, 'solver'):
-        _global_signal_handler.solver.cleanup_threads()
-    
+    if _active_solver is not None:
+        _active_solver.cleanup_threads()
     sys.exit(0)
 
-class ConfigGenerator:
-    def __init__(self, num_configs: int, seed: int = None, use_l2o: bool = False):
-        self.num_configs = num_configs
-        self.use_l2o = use_l2o
-        if seed is not None:
-            random.seed(seed)
-        
-    def generate_configs(self) -> List[List[str]]:
-        configs = [[], ["--mcsat", "--mcsat-na-bound"]]  # Always include empty config and na bound
-        if self.use_l2o:
-            configs.append(["--mcsat", "--mcsat-l2o"])
-        
-        for _ in range(self.num_configs - 2):
-            options = ["--mcsat"]  # Start with base mcsat option
-            if random.random() < 0.9:
-                options.append(f"--mcsat-rand-dec-seed={random.randint(1, 1000000)}")
-            if random.random() < 0.9:
-                options.append(f"--mcsat-rand-dec-freq={random.uniform(0, 1):.2f}")
-            if random.random() < 0.5:
-                options.append("--mcsat-na-nlsat")
-            if random.random() < 0.5:
-                options.append("--mcsat-na-mgcd")
-            if random.random() < 0.5:
-                options.append("--mcsat-na-bound")
-            if random.random() < 0.5:
-                options.append("--mcsat-partial-restart")
-            if self.use_l2o and random.random() < 0.5:
-                options.append("--mcsat-l2o")
 
-            if len(options) == 1:  # If only base option, add a random one
-                options.append(random.choice([
-                    f"--mcsat-rand-dec-freq={random.uniform(0, 1):.2f}",
-                    f"--mcsat-rand-dec-seed={random.randint(1, 1000000)}"
-                ]))
-                
-            configs.append(options)
-            
-        return configs
+def generate_configs(num_configs: int, seed: int = None, use_l2o: bool = False) -> List[List[str]]:
+    if seed is not None:
+        random.seed(seed)
+
+    configs = [[], ["--mcsat", "--mcsat-na-bound"]]
+    if use_l2o:
+        configs.append(["--mcsat", "--mcsat-l2o"])
+
+    n_fixed = len(configs)
+    for _ in range(num_configs - n_fixed):
+        options = ["--mcsat"]
+        if random.random() < 0.9:
+            options.append(f"--mcsat-rand-dec-seed={random.randint(1, 1000000)}")
+        if random.random() < 0.9:
+            options.append(f"--mcsat-rand-dec-freq={random.uniform(0, 1):.2f}")
+        if random.random() < 0.5:
+            options.append("--mcsat-na-nlsat")
+        if random.random() < 0.5:
+            options.append("--mcsat-na-mgcd")
+        if random.random() < 0.5:
+            options.append("--mcsat-na-bound")
+        if random.random() < 0.5:
+            options.append("--mcsat-partial-restart")
+        if use_l2o and random.random() < 0.5:
+            options.append("--mcsat-l2o")
+
+        if len(options) == 1:
+            options.append(random.choice([
+                f"--mcsat-rand-dec-freq={random.uniform(0, 1):.2f}",
+                f"--mcsat-rand-dec-seed={random.randint(1, 1000000)}"
+            ]))
+
+        configs.append(options)
+
+    return configs
+
 
 class PortfolioSolver:
     def __init__(self, yices_path, smt2_file, num_threads, verbose=False, seed=None, use_l2o=False):
@@ -92,19 +90,8 @@ class PortfolioSolver:
         self.stop_event = threading.Event()
         self.start_time = None
         self.processes = []
+        self._lock = threading.Lock()
         self._solution = None
-        _global_signal_handler.solver = self
-
-    @property
-    def solution(self):
-        return self._solution
-
-    @solution.setter
-    def solution(self, value):
-        if not self.stop_event.is_set():
-            self._solution = value
-            self.stop_event.set()
-            self.cleanup_threads()
 
     def log(self, message):
         if self.verbose:
@@ -112,56 +99,58 @@ class PortfolioSolver:
 
     def cleanup_threads(self):
         self.stop_event.set()
-        for process in self.processes:
+        with self._lock:
+            processes, self.processes = self.processes, []
+        for process in processes:
             try:
                 if process and process.poll() is None:
                     process.kill()
             except (ProcessLookupError, OSError):
                 pass
-        self.threads.clear()
-        self.processes.clear()
+
+    def try_set_solution(self, value):
+        with self._lock:
+            if self.stop_event.is_set():
+                return
+            self._solution = value
+            self.stop_event.set()
+        self.cleanup_threads()
 
     def run_yices(self, thread_id, params):
-        process = None
         try:
             cmd = [self.yices_path] + params + [self.smt2_file]
             self.log(f"Thread {thread_id} starting with params: {' '.join(params)}")
-            
+
             process = subprocess.Popen(
                 cmd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True
             )
-            self.processes.append(process)
-            
+            with self._lock:
+                self.processes.append(process)
+
             stdout, stderr = process.communicate()
-            
+
             if not self.stop_event.is_set():
-                if "unsat" in stdout.lower():
+                lines = {line.strip().lower() for line in stdout.splitlines()}
+                if "unsat" in lines:
                     self.log(f"Thread {thread_id} found UNSAT solution")
-                    self.solution = ("unsat", stdout, thread_id, params)
-                elif "sat" in stdout.lower():
+                    self.try_set_solution(("unsat", stdout, thread_id, params))
+                elif "sat" in lines:
                     self.log(f"Thread {thread_id} found SAT solution")
-                    self.solution = ("sat", stdout, thread_id, params)
+                    self.try_set_solution(("sat", stdout, thread_id, params))
                 else:
                     self.log(f"Thread {thread_id} finished without finding solution")
-                
+
         except Exception as e:
             if not self.stop_event.is_set():
                 self.log(f"Error in thread {thread_id}: {e}")
-        finally:
-            if process and process.poll() is None:
-                try:
-                    process.kill()
-                except (ProcessLookupError, OSError):
-                    pass
 
     def solve(self):
         try:
-            config_generator = ConfigGenerator(self.num_threads, self.seed, self.use_l2o)
-            param_sets = config_generator.generate_configs()
-            
+            param_sets = generate_configs(self.num_threads, self.seed, self.use_l2o)
+
             self.start_time = time.time()
             self.log(f"Starting portfolio solver with {self.num_threads} threads")
             self.log(f"Using yices_smt2 from: {self.yices_path}")
@@ -182,8 +171,8 @@ class PortfolioSolver:
             for thread in self.threads:
                 thread.join()
 
-            if self.solution is not None:
-                result, output, thread_id, params = self.solution
+            if self._solution is not None:
+                result, output, thread_id, params = self._solution
                 self.log(f"Solution found by thread {thread_id} with params: {' '.join(params) if params else '(default)'}")
                 return result, output
             return "unknown", "No solution found"
@@ -191,11 +180,14 @@ class PortfolioSolver:
         finally:
             self.cleanup_threads()
 
+
 def main():
+    global _active_solver
+
     signal.signal(signal.SIGINT, _global_signal_handler)
     signal.signal(signal.SIGTERM, _global_signal_handler)
     signal.signal(signal.SIGQUIT, _global_signal_handler)
-    
+
     parser = argparse.ArgumentParser(description='Portfolio solver using yices_smt2')
     parser.add_argument('--yices', default='yices_smt2', help='Path to yices_smt2 executable (default: yices_smt2)')
     parser.add_argument('-n', '--num-threads', type=int, default=4, help='Number of threads to use (default: 4)')
@@ -203,15 +195,16 @@ def main():
     parser.add_argument('--seed', type=int, help='Random seed for configuration generation')
     parser.add_argument('--mcsat-l2o', action='store_true', help='Use MCSAT L2O option as one of the configuration')
     parser.add_argument('smt2_file', help='Path to SMT2 benchmark file')
-    
+
     args = parser.parse_args()
 
-    # Get the directory of this script
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    
-    # If yices path is not absolute, make it relative to script directory
     if not os.path.isabs(args.yices):
-        args.yices = os.path.join(script_dir, args.yices)
+        on_path = shutil.which(args.yices)
+        if on_path:
+            args.yices = on_path
+        else:
+            script_dir = os.path.dirname(os.path.abspath(__file__))
+            args.yices = os.path.join(script_dir, args.yices)
 
     if not os.path.exists(args.yices):
         print(f"Error: yices_smt2 executable not found at {args.yices}", file=sys.stderr)
@@ -222,8 +215,8 @@ def main():
         sys.exit(1)
 
     try:
-        solver = PortfolioSolver(args.yices, args.smt2_file, args.num_threads, args.verbose, args.seed, args.mcsat_l2o)
-        result, output = solver.solve()
+        _active_solver = PortfolioSolver(args.yices, args.smt2_file, args.num_threads, args.verbose, args.seed, args.mcsat_l2o)
+        result, output = _active_solver.solve()
         print(result)
     except KeyboardInterrupt:
         print("\nInterrupted by user", file=sys.stderr)
@@ -233,4 +226,4 @@ def main():
         sys.exit(1)
 
 if __name__ == "__main__":
-    main() 
+    main()


### PR DESCRIPTION
Substring matching ("sat" in stdout) produced false positives whenever yices emitted an error message containing "mcsat" -- e.g. reporting SAT on unsupported quantified problems. Switch to exact line-set membership so only a bare sat/unsat SMT-LIB response token matches.

Fix two concurrency bugs: concurrent appends and iteration over self.processes without a lock could raise RuntimeError; the solution setter's check-then-set was not atomic, allowing two threads to both commit a result. Guard both with a threading.Lock.

Fix --mcsat-l2o generating one extra config (num_configs+1 instead of num_configs) by computing n_fixed from the actual fixed-config list.

Fix --yices path resolution to try shutil.which() before falling back to the script directory, so a binary on $PATH can be used by name.

Simplify: flatten ConfigGenerator class to a function, replace the property/setter with try_set_solution(), use a module-level _active_solver instead of attaching state to the signal handler function, and drop the unreachable subprocess kill in run_yices finally.