### PR TITLE
move mk_composite and get_composite

### DIFF
--- a/src/mcsat/preprocessor.c
+++ b/src/mcsat/preprocessor.c
@@ -85,91 +85,6 @@ void preprocessor_set(preprocessor_t* pre, term_t t, term_t t_pre) {
   ivector_push(&pre->preprocess_map_list, t);
 }
 
-typedef struct composite_term1_s {
-  uint32_t arity;  // number of subterms
-  term_t arg[1];  // real size = arity
-} composite_term1_t;
-
-static
-composite_term1_t composite_for_noncomposite;
-
-static
-composite_term_t* get_composite(term_table_t* terms, term_kind_t kind, term_t t) {
-  assert(term_is_composite(terms, t));
-  assert(term_kind(terms, t) == kind);
-  assert(is_pos_term(t));
-
-  switch (kind) {
-  case ITE_TERM:           // if-then-else
-  case ITE_SPECIAL:        // special if-then-else term (NEW: EXPERIMENTAL)
-    return ite_term_desc(terms, t);
-  case EQ_TERM:            // equality
-    return eq_term_desc(terms, t);
-  case OR_TERM:            // n-ary OR
-    return or_term_desc(terms, t);
-  case XOR_TERM:           // n-ary XOR
-    return xor_term_desc(terms, t);
-  case ARITH_BINEQ_ATOM:   // equality: (t1 == t2)  (between two arithmetic terms)
-    return arith_bineq_atom_desc(terms, t);
-  case ARITH_EQ_ATOM: {
-    composite_for_noncomposite.arity = 1;
-    composite_for_noncomposite.arg[0] = arith_eq_arg(terms, t);
-    return (composite_term_t*)&composite_for_noncomposite;
-  }
-  case ARITH_GE_ATOM: {
-    composite_for_noncomposite.arity = 1;
-    composite_for_noncomposite.arg[0] = arith_ge_arg(terms, t);
-    return (composite_term_t*)&composite_for_noncomposite;
-  }
-  case ARITH_FF_BINEQ_ATOM:
-    return arith_ff_bineq_atom_desc(terms, t);
-  case ARITH_FF_EQ_ATOM: {
-    composite_for_noncomposite.arity = 1;
-    composite_for_noncomposite.arg[0] = arith_ff_eq_arg(terms, t);
-    return (composite_term_t*)&composite_for_noncomposite;
-  }
-  case APP_TERM:           // application of an uninterpreted function
-    return app_term_desc(terms, t);
-  case ARITH_RDIV:          // division: (/ x y)
-    return arith_rdiv_term_desc(terms, t);
-  case ARITH_IDIV:          // division: (div x y) as defined in SMT-LIB 2
-    return arith_idiv_term_desc(terms, t);
-  case ARITH_MOD:          // remainder: (mod x y) is y - x * (div x y)
-    return arith_mod_term_desc(terms, t);
-  case UPDATE_TERM:
-    return update_term_desc(terms, t);
-  case DISTINCT_TERM:
-    return distinct_term_desc(terms, t);
-  case BV_ARRAY:
-    return bvarray_term_desc(terms, t);
-  case BV_DIV:
-    return bvdiv_term_desc(terms, t);
-  case BV_REM:
-    return bvrem_term_desc(terms, t);
-  case BV_SDIV:
-    return bvsdiv_term_desc(terms, t);
-  case BV_SREM:
-    return bvsrem_term_desc(terms, t);
-  case BV_SMOD:
-    return bvsmod_term_desc(terms, t);
-  case BV_SHL:
-    return bvshl_term_desc(terms, t);
-  case BV_LSHR:
-    return bvlshr_term_desc(terms, t);
-  case BV_ASHR:
-    return bvashr_term_desc(terms, t);
-  case BV_EQ_ATOM:
-    return bveq_atom_desc(terms, t);
-  case BV_GE_ATOM:
-    return bvge_atom_desc(terms, t);
-  case BV_SGE_ATOM:
-    return bvsge_atom_desc(terms, t);
-  default:
-    assert(false);
-    return NULL;
-  }
-}
-
 static bool type_needs_function_diseq_guard(type_table_t* types, type_t tau) {
   uint32_t i, n;
 
@@ -214,94 +129,6 @@ static bool type_needs_function_diseq_guard(type_table_t* types, type_t tau) {
 
 static bool term_needs_function_diseq_guard(term_table_t* terms, term_t t) {
   return type_needs_function_diseq_guard(terms->types, term_type(terms, t));
-}
-
-static
-term_t mk_composite(preprocessor_t* pre, term_kind_t kind, uint32_t n, term_t* children) {
-  term_manager_t* tm = &pre->tm;
-  term_table_t* terms = pre->terms;
-
-  switch (kind) {
-  case ITE_TERM:           // if-then-else
-  case ITE_SPECIAL:        // special if-then-else term (NEW: EXPERIMENTAL)
-  {
-    assert(n == 3);
-    term_t type = super_type(pre->terms->types, term_type(terms, children[1]), term_type(terms, children[2]));
-    assert(type != NULL_TYPE);
-    return mk_ite(tm, children[0], children[1], children[2], type);
-  }
-  case EQ_TERM:            // equality
-    assert(n == 2);
-    return mk_eq(tm, children[0], children[1]);
-  case OR_TERM:            // n-ary OR
-    assert(n > 1);
-    return mk_or(tm, n, children);
-  case XOR_TERM:           // n-ary XOR
-    return mk_xor(tm, n, children);
-  case ARITH_EQ_ATOM:
-    assert(n == 1);
-    return mk_arith_eq(tm, children[0], zero_term);
-  case ARITH_GE_ATOM:
-    assert(n == 1);
-    return mk_arith_geq(tm, children[0], zero_term);
-  case ARITH_BINEQ_ATOM:   // equality: (t1 == t2)  (between two arithmetic terms)
-    assert(n == 2);
-    return mk_arith_eq(tm, children[0], children[1]);
-  case APP_TERM:           // application of an uninterpreted function
-    assert(n > 1);
-    return mk_application(tm, children[0], n-1, children + 1);
-  case ARITH_RDIV:
-    assert(n == 2);
-    return mk_arith_rdiv(tm, children[0], children[1]);
-  case ARITH_IDIV:          // division: (div x y) as defined in SMT-LIB 2
-    assert(n == 2);
-    return mk_arith_idiv(tm, children[0], children[1]);
-  case ARITH_MOD:          // remainder: (mod x y) is y - x * (div x y)
-    assert(n == 2);
-    return mk_arith_mod(tm, children[0], children[1]);
-  case UPDATE_TERM:
-    assert(n > 2);
-    return mk_update(tm, children[0], n-2, children + 1, children[n-1]);
-  case BV_ARRAY:
-    assert(n >= 1);
-    return mk_bvarray(tm, n, children);
-  case BV_DIV:
-    assert(n == 2);
-    return mk_bvdiv(tm, children[0], children[1]);
-  case BV_REM:
-    assert(n == 2);
-    return mk_bvrem(tm, children[0], children[1]);
-  case BV_SDIV:
-    assert(n == 2);
-    return mk_bvsdiv(tm, children[0], children[1]);
-  case BV_SREM:
-    assert(n == 2);
-    return mk_bvsrem(tm, children[0], children[1]);
-  case BV_SMOD:
-    assert(n == 2);
-    return mk_bvsmod(tm, children[0], children[1]);
-  case BV_SHL:
-    assert(n == 2);
-    return mk_bvshl(tm, children[0], children[1]);
-  case BV_LSHR:
-    assert(n == 2);
-    return mk_bvlshr(tm, children[0], children[1]);
-  case BV_ASHR:
-    assert(n == 2);
-    return mk_bvashr(tm, children[0], children[1]);
-  case BV_EQ_ATOM:
-    assert(n == 2);
-    return mk_bveq(tm, children[0], children[1]);
-  case BV_GE_ATOM:
-    assert(n == 2);
-    return mk_bvge(tm, children[0], children[1]);
-  case BV_SGE_ATOM:
-    assert(n == 2);
-    return mk_bvsge(tm, children[0], children[1]);
-  default:
-    assert(false);
-    return NULL_TERM;
-  }
 }
 
 /**
@@ -642,7 +469,7 @@ term_t preprocessor_apply(preprocessor_t* pre, term_t t, ivector_t* out, bool is
           if (children_same) {
             current_pre = current;
           } else {
-            current_pre = mk_composite(pre, current_kind, n, children.data);
+            current_pre = mk_composite(&pre->tm, current_kind, n, children.data);
           }
         }
       }
@@ -687,7 +514,7 @@ term_t preprocessor_apply(preprocessor_t* pre, term_t t, ivector_t* out, bool is
         if (children_same) {
           current_pre = current;
         } else {
-          current_pre = mk_composite(pre, current_kind, n, children.data);
+          current_pre = mk_composite(&pre->tm, current_kind, n, children.data);
         }
       }
 
@@ -1072,7 +899,7 @@ term_t preprocessor_apply(preprocessor_t* pre, term_t t, ivector_t* out, bool is
         if (children_same) {
           current_pre = current;
         } else {
-          current_pre = mk_composite(pre, current_kind, n, children.data);
+          current_pre = mk_composite(&pre->tm, current_kind, n, children.data);
         }
       }
 

--- a/src/mcsat/utils/substitution.c
+++ b/src/mcsat/utils/substitution.c
@@ -17,8 +17,6 @@ void substitution_destruct(substitution_t* subst) {
 }
 
 /**
- * Construct a composite term.
- *
  * The main application of substitution is in the context of conflict
  * resolution. Once of the constraints there is to make sure that if we
  * substitute x -> t in a constraint C(x) this constraint doesn't shift
@@ -29,91 +27,6 @@ void substitution_destruct(substitution_t* subst) {
  *   -> might result in just (b1 or b2): BV constraint -> Boolean constraint
  *
  */
-static inline
-term_t mk_composite(term_manager_t* tm, term_kind_t kind, uint32_t n, term_t* c) {
-
-  term_t result = NULL_TERM;
-
-  switch (kind) {
-  case EQ_TERM:            // equality
-    assert(n == 2);
-    result = mk_eq(tm, c[0], c[1]);
-    break;
-  case OR_TERM:            // n-ary OR
-    assert(n > 1);
-    result = mk_or(tm, n, c);
-    break;
-  case XOR_TERM:           // n-ary XOR
-    result = mk_xor(tm, n, c);
-    break;
-  case BV_ARRAY:
-    assert(n >= 1);
-    result = mk_bvarray(tm, n, c);
-    break;
-  case BV_DIV:
-    assert(n == 2);
-    result = mk_bvdiv(tm, c[0], c[1]);
-    break;
-  case BV_REM:
-    assert(n == 2);
-    result = mk_bvrem(tm, c[0], c[1]);
-    break;
-  case BV_SDIV:
-    assert(n == 2);
-    result = mk_bvsdiv(tm, c[0], c[1]);
-    break;
-  case BV_SREM:
-    assert(n == 2);
-    result = mk_bvsrem(tm, c[0], c[1]);
-    break;
-  case BV_SMOD:
-    assert(n == 2);
-    result = mk_bvsmod(tm, c[0], c[1]);
-    break;
-  case BV_SHL:
-    assert(n == 2);
-    result = mk_bvshl(tm, c[0], c[1]);
-    break;
-  case BV_LSHR:
-    assert(n == 2);
-    result = mk_bvlshr(tm, c[0], c[1]);
-    break;
-  case BV_ASHR:
-    assert(n == 2);
-    result = mk_bvashr(tm, c[0], c[1]);
-    break;
-  case BV_EQ_ATOM:
-    assert(n == 2);
-    result = mk_bveq(tm, c[0], c[1]);
-    break;
-  case BV_GE_ATOM:
-    assert(n == 2);
-    result = mk_bvge(tm, c[0], c[1]);
-    break;
-  case BV_SGE_ATOM:
-    assert(n == 2);
-    result = mk_bvsge(tm, c[0], c[1]);
-    break;
-  case ITE_TERM: {
-    assert(n == 3);
-    type_t tau = term_type(tm->terms, c[1]);
-    result = mk_ite(tm, c[0], c[1], c[2], tau);
-    break;
-  }
-  case ARITH_BINEQ_ATOM:
-    assert(n == 2);
-    result = mk_arith_eq(tm, c[0], c[1]);
-    break;
-  case ARITH_FF_BINEQ_ATOM:
-    assert(n == 2);
-    result = mk_arith_ff_eq(tm, c[0], c[1]);
-    break;
-  default:
-    assert(false);
-  }
-
-  return result;
-}
 
 static
 term_t substitution_run_core(substitution_t* subst, term_t t, int_hmap_t* cache, const int_hmap_t* frontier) {

--- a/src/terms/term_manager.c
+++ b/src/terms/term_manager.c
@@ -6598,3 +6598,107 @@ term_t mk_arith_elim_poly(term_manager_t *mngr, polynomial_t *p, term_t t) {
 
   return mk_arith_term(mngr, b);
 }
+
+term_t mk_composite(term_manager_t *tm, term_kind_t kind, uint32_t n, term_t* children) {
+  term_table_t* terms = tm->terms;
+
+  switch (kind) {
+  case ITE_TERM:           // if-then-else
+  case ITE_SPECIAL:        // special if-then-else term (NEW: EXPERIMENTAL)
+  {
+    assert(n == 3);
+    term_t type = super_type(terms->types, term_type(terms, children[1]), term_type(terms, children[2]));
+    assert(type != NULL_TYPE);
+    return mk_ite(tm, children[0], children[1], children[2], type);
+  }
+  case EQ_TERM:            // equality
+    assert(n == 2);
+    return mk_eq(tm, children[0], children[1]);
+  case OR_TERM:            // n-ary OR
+    assert(n > 1);
+    return mk_or(tm, n, children);
+  case XOR_TERM:           // n-ary XOR
+    return mk_xor(tm, n, children);
+  case ARITH_EQ_ATOM:
+    assert(n == 1);
+    return mk_arith_eq(tm, children[0], zero_term);
+  case ARITH_GE_ATOM:
+    assert(n == 1);
+    return mk_arith_geq(tm, children[0], zero_term);
+  case ARITH_BINEQ_ATOM:   // equality: (t1 == t2)  (between two arithmetic terms)
+    assert(n == 2);
+    return mk_arith_eq(tm, children[0], children[1]);
+  case ARITH_FF_EQ_ATOM:
+    assert(n == 1);
+    return mk_arith_ff_eq(tm, children[0], zero_term);
+  case ARITH_FF_BINEQ_ATOM:
+    assert(n == 2);
+    return mk_arith_ff_eq(tm, children[0], children[1]);
+  case APP_TERM:           // application of an uninterpreted function
+    assert(n > 1);
+    return mk_application(tm, children[0], n-1, children + 1);
+  case ARITH_RDIV:
+    assert(n == 2);
+    return mk_arith_rdiv(tm, children[0], children[1]);
+  case ARITH_IDIV:          // division: (div x y) as defined in SMT-LIB 2
+    assert(n == 2);
+    return mk_arith_idiv(tm, children[0], children[1]);
+  case ARITH_MOD:          // remainder: (mod x y) is y - x * (div x y)
+    assert(n == 2);
+    return mk_arith_mod(tm, children[0], children[1]);
+  case ARITH_IS_INT_ATOM:
+    assert(n == 1);
+    return mk_arith_is_int(tm, children[0]);
+  case ARITH_FLOOR:
+    assert(n == 1);
+    return mk_arith_floor(tm, children[0]);
+  case ARITH_CEIL:
+    assert(n == 1);
+    return mk_arith_ceil(tm, children[0]);
+  case ARITH_ABS:
+    assert(n == 1);
+    return mk_arith_abs(tm, children[0]);
+  case UPDATE_TERM:
+    assert(n > 2);
+    return mk_update(tm, children[0], n-2, children + 1, children[n-1]);
+  case BV_ARRAY:
+    assert(n >= 1);
+    return mk_bvarray(tm, n, children);
+  case BV_DIV:
+    assert(n == 2);
+    return mk_bvdiv(tm, children[0], children[1]);
+  case BV_REM:
+    assert(n == 2);
+    return mk_bvrem(tm, children[0], children[1]);
+  case BV_SDIV:
+    assert(n == 2);
+    return mk_bvsdiv(tm, children[0], children[1]);
+  case BV_SREM:
+    assert(n == 2);
+    return mk_bvsrem(tm, children[0], children[1]);
+  case BV_SMOD:
+    assert(n == 2);
+    return mk_bvsmod(tm, children[0], children[1]);
+  case BV_SHL:
+    assert(n == 2);
+    return mk_bvshl(tm, children[0], children[1]);
+  case BV_LSHR:
+    assert(n == 2);
+    return mk_bvlshr(tm, children[0], children[1]);
+  case BV_ASHR:
+    assert(n == 2);
+    return mk_bvashr(tm, children[0], children[1]);
+  case BV_EQ_ATOM:
+    assert(n == 2);
+    return mk_bveq(tm, children[0], children[1]);
+  case BV_GE_ATOM:
+    assert(n == 2);
+    return mk_bvge(tm, children[0], children[1]);
+  case BV_SGE_ATOM:
+    assert(n == 2);
+    return mk_bvsge(tm, children[0], children[1]);
+  default:
+    assert(false);
+    return NULL_TERM;
+  }
+}

--- a/src/terms/term_manager.h
+++ b/src/terms/term_manager.h
@@ -755,5 +755,6 @@ extern term_t mk_bvarith_poly(term_manager_t *manager, bvpoly_t *p, uint32_t n, 
  */
 extern term_t mk_arith_elim_poly(term_manager_t *manager, polynomial_t *p, term_t t);
 
+extern term_t mk_composite(term_manager_t *tm, term_kind_t kind, uint32_t n, term_t* children);
 
 #endif /* __TERM_MANAGER_H */

--- a/src/terms/terms.c
+++ b/src/terms/terms.c
@@ -1297,7 +1297,7 @@ void add_unit_type_rep(term_table_t *table, type_t tau, term_t t) {
          term_type(table, t) == tau);
 
   p = int_hmap_get(&table->utbl, tau);
-  assert(p->val == EMPTY_KEY); // i.e., -1
+  assert(p->val == -1); // i.e., EMPTY_KEY
   p->val = t;
 }
 
@@ -1316,7 +1316,7 @@ void store_unit_type_rep(term_table_t *table, type_t tau, term_t t) {
          term_type(table, t) == tau);
 
   p = int_hmap_get(&table->utbl, tau);
-  if (p->val == EMPTY_KEY) {
+  if (p->val == -1) { // i.e., EMPTY_KEY
     p->val = t;
   }
   assert(p->val == t);
@@ -3821,4 +3821,93 @@ void term_table_gc(term_table_t *table, bool keep_named) {
 
   // clear the marks
   clear_bitvector(table->mark, n);
+}
+
+
+/*
+ * Composite term handling
+ */
+
+typedef struct composite_term1_s {
+  uint32_t arity;  // number of subterms
+  term_t arg[1];  // real size = arity
+} composite_term1_t;
+
+static
+composite_term1_t composite_for_noncomposite;
+
+composite_term_t* get_composite(term_table_t* terms, term_kind_t kind, term_t t) {
+  assert(term_is_composite(terms, t));
+  assert(term_kind(terms, t) == kind);
+  assert(is_pos_term(t));
+
+  switch (kind) {
+  case ITE_TERM:           // if-then-else
+  case ITE_SPECIAL:        // special if-then-else term (NEW: EXPERIMENTAL)
+    return ite_term_desc(terms, t);
+  case EQ_TERM:            // equality
+    return eq_term_desc(terms, t);
+  case OR_TERM:            // n-ary OR
+    return or_term_desc(terms, t);
+  case XOR_TERM:           // n-ary XOR
+    return xor_term_desc(terms, t);
+  case ARITH_BINEQ_ATOM:   // equality: (t1 == t2)  (between two arithmetic terms)
+    return arith_bineq_atom_desc(terms, t);
+  case ARITH_EQ_ATOM: {
+    composite_for_noncomposite.arity = 1;
+    composite_for_noncomposite.arg[0] = arith_eq_arg(terms, t);
+    return (composite_term_t*)&composite_for_noncomposite;
+  }
+  case ARITH_GE_ATOM: {
+    composite_for_noncomposite.arity = 1;
+    composite_for_noncomposite.arg[0] = arith_ge_arg(terms, t);
+    return (composite_term_t*)&composite_for_noncomposite;
+  }
+  case ARITH_FF_BINEQ_ATOM:
+    return arith_ff_bineq_atom_desc(terms, t);
+  case ARITH_FF_EQ_ATOM: {
+    composite_for_noncomposite.arity = 1;
+    composite_for_noncomposite.arg[0] = arith_ff_eq_arg(terms, t);
+    return (composite_term_t*)&composite_for_noncomposite;
+  }
+  case APP_TERM:           // application of an uninterpreted function
+    return app_term_desc(terms, t);
+  case ARITH_RDIV:          // division: (/ x y)
+    return arith_rdiv_term_desc(terms, t);
+  case ARITH_IDIV:          // division: (div x y) as defined in SMT-LIB 2
+    return arith_idiv_term_desc(terms, t);
+  case ARITH_MOD:          // remainder: (mod x y) is y - x * (div x y)
+    return arith_mod_term_desc(terms, t);
+  case UPDATE_TERM:
+    return update_term_desc(terms, t);
+  case DISTINCT_TERM:
+    return distinct_term_desc(terms, t);
+  case BV_ARRAY:
+    return bvarray_term_desc(terms, t);
+  case BV_DIV:
+    return bvdiv_term_desc(terms, t);
+  case BV_REM:
+    return bvrem_term_desc(terms, t);
+  case BV_SDIV:
+    return bvsdiv_term_desc(terms, t);
+  case BV_SREM:
+    return bvsrem_term_desc(terms, t);
+  case BV_SMOD:
+    return bvsmod_term_desc(terms, t);
+  case BV_SHL:
+    return bvshl_term_desc(terms, t);
+  case BV_LSHR:
+    return bvlshr_term_desc(terms, t);
+  case BV_ASHR:
+    return bvashr_term_desc(terms, t);
+  case BV_EQ_ATOM:
+    return bveq_atom_desc(terms, t);
+  case BV_GE_ATOM:
+    return bvge_atom_desc(terms, t);
+  case BV_SGE_ATOM:
+    return bvsge_atom_desc(terms, t);
+  default:
+    assert(false);
+    return NULL;
+  }
 }

--- a/src/terms/terms.h
+++ b/src/terms/terms.h
@@ -1832,4 +1832,11 @@ static inline bool term_idx_is_marked(const term_table_t *table, int32_t i) {
 extern void term_table_gc(term_table_t *table, bool keep_named);
 
 
+/*
+ * Composite term handling: get the composite descriptor for a term.
+ * The term must be positive and its kind must match 'kind'.
+ */
+extern composite_term_t* get_composite(term_table_t* terms, term_kind_t kind, term_t t);
+
+
 #endif /* __TERMS_H */


### PR DESCRIPTION
This PR does the following changes:
- get_composite is moved from preprocessor.c to terms.c
- mk_composite is moved from preprocessor.c and substitution.c to term_manager.c
- FF cases added to mk_composite