### PR TITLE
mcsat: tighten trail cache update and GC sweep loops

### DIFF
--- a/src/mcsat/trail.c
+++ b/src/mcsat/trail.c
@@ -306,30 +306,24 @@ void trail_gc_mark(mcsat_trail_t* trail, gc_info_t* gc_vars) {
 }
 
 void trail_gc_sweep(mcsat_trail_t* trail, const gc_info_t* gc_vars) {
-  variable_t var;
-
   assert(gc_vars->is_id);
 
-  // Remove from the model cache, otherwise the cache might contain wrongly
-  // typed variables
-  for (var = 0; var < trail->model.size; ++ var) {
-    if (var != variable_null && gc_info_get_reloc(gc_vars, var) == variable_null) {
-      assert(!trail_has_value(trail, var));
-      if (mcsat_model_has_value(&trail->model, var)) {
-        mcsat_model_unset_value(&trail->model, var);
-      }
-      assert(!trail_has_value(trail, var));
+  // model, target_cache, and best_cache grow in lockstep with trail->level
+  // via trail_new_variable_notify; iterate the common range and clean every
+  // unmarked variable from all three caches in one pass. Skip var 0 (the
+  // variable_null sentinel).
+  for (uint32_t var = 1; var < trail->model.size; ++var) {
+    if (gc_info_get_reloc(gc_vars, var) != variable_null) {
+      continue;
     }
-  }
-  for (var = 0; var < trail->target_cache.size; ++ var) {
-    if (var != variable_null && gc_info_get_reloc(gc_vars, var) == variable_null &&
-	mcsat_model_has_value(&trail->target_cache, var)) {
+    assert(!trail_has_value(trail, var));
+    if (mcsat_model_has_value(&trail->model, var)) {
+      mcsat_model_unset_value(&trail->model, var);
+    }
+    if (mcsat_model_has_value(&trail->target_cache, var)) {
       mcsat_model_unset_value(&trail->target_cache, var);
     }
-  }
-  for (var = 0; var < trail->best_cache.size; ++ var) {
-    if (var != variable_null && gc_info_get_reloc(gc_vars, var) == variable_null &&
-	mcsat_model_has_value(&trail->best_cache, var)) {
+    if (mcsat_model_has_value(&trail->best_cache, var)) {
       mcsat_model_unset_value(&trail->best_cache, var);
     }
   }

--- a/src/mcsat/trail.c
+++ b/src/mcsat/trail.c
@@ -427,23 +427,25 @@ void trail_recache(mcsat_trail_t* trail, uint32_t round) {
 
 void trail_update_extra_cache(mcsat_trail_t* trail) {
   // update target and best cache w.r.t. current trail if the trail size is bigger
-  variable_t var;
-  if (trail->elements.size > trail->best_depth) {
-    // keep only the values for assigned variables as best promising assignment
-    for (var = 0; var < trail->best_cache.size; ++var) {
-      if (trail_has_value(trail, var)) {
-        mcsat_model_set_value(&trail->best_cache, var, trail_get_value(trail, var));
-      }
+  const bool update_best   = trail->elements.size > trail->best_depth;
+  const bool update_target = trail->elements.size > trail->target_depth;
+  if (!update_best && !update_target) {
+    return;
+  }
+  for (uint32_t i = 0; i < trail->elements.size; ++i) {
+    variable_t var = trail->elements.data[i];
+    const mcsat_value_t* val = trail_get_value(trail, var);
+    if (update_best) {
+      mcsat_model_set_value(&trail->best_cache, var, val);
     }
+    if (update_target) {
+      mcsat_model_set_value(&trail->target_cache, var, val);
+    }
+  }
+  if (update_best) {
     trail->best_depth = trail->elements.size;
   }
-  if (trail->elements.size > trail->target_depth) {
-    // save the assigned values as target assignment
-    for (var = 0; var < trail->target_cache.size; ++var) {
-      if (trail_has_value(trail, var)) {
-        mcsat_model_set_value(&trail->target_cache, var, trail_get_value(trail, var));
-      }
-    }
+  if (update_target) {
     trail->target_depth = trail->elements.size;
   }
 }


### PR DESCRIPTION
Two small perf cleanups in src/mcsat/trail.c, no behavior change:

  - **`trail_update_extra_cache`**: replace the two O(|cache|) loops with a single pass over `trail->elements` (O(|trail|)), fused so both caches
   share one `trail_get_value` call.
  - **`trail_gc_sweep`**: collapse the three per-cache loops into one — each unmarked variable now costs one `gc_info_get_reloc` lookup instead
  of three.
