### PR TITLE
smt2 array model display format

### DIFF
--- a/src/frontend/smt2/smt2_commands.c
+++ b/src/frontend/smt2/smt2_commands.c
@@ -371,9 +371,15 @@ static void smt2_push_name(smt2_name_stack_t *s, char *name) {
 /*
  * Remove names on top of the stack and remove them from the term_name table
  * - ptr = new top: names[0 ... ptr-1] are kept
+ *
+ * Also drop any array-constant markers in __smt2_globals.array_const_terms
+ * for the popped term ids. Most popped names are not arrays, so we look up
+ * the marker first and only erase if present.
  */
 static void smt2_pop_term_names(smt2_name_stack_t *s, uint32_t ptr) {
   char *name;
+  term_t t;
+  int_hmap_pair_t *p;
   uint32_t n;
 
   n = s->top;
@@ -381,7 +387,13 @@ static void smt2_pop_term_names(smt2_name_stack_t *s, uint32_t ptr) {
     n --;
     name = s->names[n];
 
-    assert(yices_get_term_by_name(name) != NULL_TERM);
+    t = yices_get_term_by_name(name);
+    assert(t != NULL_TERM);
+    p = int_hmap_find(&__smt2_globals.array_const_terms, t);
+    if (p != NULL) {
+      int_hmap_erase(&__smt2_globals.array_const_terms, p);
+    }
+
     yices_remove_term_name(name);
     assert(yices_get_term_by_name(name) == NULL_TERM);
 
@@ -4078,7 +4090,9 @@ static void print_smt2_model(smt2_pp_t *printer, smt2_model_t *sm) {
      */
     if (good_object(vtbl, v)) {
       tau = term_type(terms, t);
-      smt2_pp_def(printer, vtbl, sm->names.data[i], tau, v);
+      bool array_const =
+        int_hmap_find(&__smt2_globals.array_const_terms, t) != NULL;
+      smt2_pp_def(printer, vtbl, sm->names.data[i], tau, v, array_const);
     }
   }
   pp_close_block(&printer->pp, true);
@@ -4721,6 +4735,7 @@ static void init_smt2_globals(smt2_globals_t *g) {
   init_named_term_stack(&g->named_asserts);
 
   init_pvector(&g->model_term_names, 0);
+  init_int_hmap(&g->array_const_terms, 0);
 
   g->unsat_core = NULL;
   g->unsat_assumptions = NULL;
@@ -4789,6 +4804,7 @@ static void delete_smt2_globals(smt2_globals_t *g) {
   delete_named_term_stack(&g->named_asserts);
 
   delete_string_vector(&g->model_term_names);
+  delete_int_hmap(&g->array_const_terms);
 
   if (g->unsat_core != NULL) {
     free_assumptions(g->unsat_core);
@@ -7020,6 +7036,20 @@ void smt2_declare_fun(const char *name, uint32_t n, type_t *tau) {
     save_term_name(&__smt2_globals, name);
     save_name_for_model(&__smt2_globals, name);
 
+    /*
+     * Record array-constant declarations so that the model printer can
+     * emit them in SMT-LIB store/const form rather than as a function
+     * with parameters. A 0-arity declaration whose internal Yices type
+     * is a unary function type can only have come from (Array K V) in
+     * the SMT-LIB grammar (directly, via define-sort, or nested).
+     */
+    if (n == 0
+        && is_function_type(__yices_globals.types, sigma)
+        && function_type_arity(__yices_globals.types, sigma) == 1) {
+      int_hmap_pair_t *p = int_hmap_get(&__smt2_globals.array_const_terms, t);
+      p->val = 1;
+    }
+
     report_success();
   }
 }
@@ -7188,10 +7218,14 @@ void smt2_reset_assertions(void) {
       ivector_reset(&g->val_vector);
 
       /*
-       * Reset the internal name tables, unless global_decls is set
+       * Reset the internal name tables, unless global_decls is set.
+       * yices_reset_tables() recycles term ids, so we must also drop
+       * stale array-constant markers; otherwise they could alias
+       * freshly minted unrelated terms after the reset.
        */
       if (!g->global_decls) {
         yices_reset_tables();
+        int_hmap_reset(&g->array_const_terms);
       }
 
       // build a fresh empty context

--- a/src/frontend/smt2/smt2_commands.h
+++ b/src/frontend/smt2/smt2_commands.h
@@ -47,6 +47,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#include "utils/int_hash_map.h"
 #include "utils/int_vectors.h"
 #include "utils/ptr_vectors.h"
 #include "utils/string_hash_map.h"
@@ -429,6 +430,15 @@ typedef struct smt2_globals_s {
   // This is used if clean_model_format is false to keep track of all
   // terms whose value we may need to print.
   pvector_t model_term_names;
+
+  // Map term_id -> 1 for term ids that were declared as SMT-LIB array
+  // constants (i.e., via (declare-fun s () (Array K V)) or
+  // (declare-const s (Array K V))). We record this here because once
+  // the term/type are interned, Yices' type system no longer
+  // distinguishes Array K V from a unary function. Used by
+  // print_smt2_model to emit (define-fun s () (Array K V) (store ...))
+  // instead of the function form (define-fun s ((x!0 K)) V (ite ...)).
+  int_hmap_t array_const_terms;
 
   // data structures for unsat cores/unsat assumptions
   // allocated on demand

--- a/src/frontend/smt2/smt2_printer.c
+++ b/src/frontend/smt2/smt2_printer.c
@@ -756,14 +756,25 @@ static void smt2_pp_update_definition(smt2_pp_t *printer, value_table_t *table, 
 /*
  * Print a definition in the SMT2 style.
  * - this prints (define-fun name () tau value)
+ *
+ * If array_const is true, the value is rendered as a 0-arity constant
+ * using store / (as const tau) regardless of the value's internal
+ * representation as a function or update. This matches the SMT-LIB
+ * model format for symbols declared via the Array sort.
  */
-void smt2_pp_def(smt2_pp_t *printer, value_table_t *table, const char *name, type_t tau, value_t c) {
+void smt2_pp_def(smt2_pp_t *printer, value_table_t *table, const char *name,
+                 type_t tau, value_t c, bool array_const) {
   type_table_t *types;
 
   types = table->type_table;
   pp_open_block(&printer->pp, PP_OPEN_SMT2_DEF);
   smt2_pp_symbol(printer, name);
-  if (object_is_function(table, c)) {
+  if (array_const) {
+    // (define-fun name () (Array K V) <store/const value>)
+    pp_string(&printer->pp, "()");
+    smt2_pp_type(printer, types, tau);
+    smt2_pp_object_in_def(printer, table, tau, c);
+  } else if (object_is_function(table, c)) {
     smt2_pp_function_params(printer, types, tau);
     smt2_pp_function_definition(printer, table, tau, c);
   } else if (object_is_update(table, c)) {

--- a/src/frontend/smt2/smt2_printer.h
+++ b/src/frontend/smt2/smt2_printer.h
@@ -125,9 +125,16 @@ extern void smt2_pp_queued_functions(smt2_pp_t *printer, value_table_t *table, b
  * Print a definition in the SMT2 style:
  *
  *   (define-fun name () tau value)
+ *
+ * If array_const is true, the definition is rendered as a 0-arity
+ * constant of array type, with the value built from store/(as const ...)
+ * instead of as a function with parameters and an if-then-else cascade.
+ * This is required for symbols originally declared via the SMT-LIB
+ * Array sort, since the model output must match the declaration's
+ * arity and sort.
  */
 extern void smt2_pp_def(smt2_pp_t *printer, value_table_t *table, const char *name,
-			type_t tau, value_t c);
+			type_t tau, value_t c, bool array_const);
 
 
 /*

--- a/tests/regress/iss390_array_basic.smt2
+++ b/tests/regress/iss390_array_basic.smt2
@@ -1,0 +1,10 @@
+; Issue #390: SMT-LIB Array-declared constants must be printed in the
+; model as 0-arity (define-fun name () (Array K V) (store ... (as const ...) ...))
+; rather than as a function (define-fun name ((x!0 K)) V (ite ...)).
+(set-logic QF_AUFLIA)
+(declare-fun a () (Array Int Int))
+(assert (= (select a 0) 1))
+(assert (= (select a 1) 3))
+(assert (= (select a 2) 5))
+(check-sat)
+(get-model)

--- a/tests/regress/iss390_array_basic.smt2.gold
+++ b/tests/regress/iss390_array_basic.smt2.gold
@@ -1,0 +1,2 @@
+sat
+((define-fun a () (Array Int Int) (store (store (store ((as const (Array Int Int)) 4) 2 5) 1 3) 0 1)))

--- a/tests/regress/iss390_array_const.smt2
+++ b/tests/regress/iss390_array_const.smt2
@@ -1,0 +1,9 @@
+; Issue #390: declare-const path for SMT-LIB arrays must also render as
+; a 0-arity Array constant in (get-model).
+(set-logic QF_AUFLIA)
+(declare-const a (Array Int Int))
+(declare-const b Int)
+(assert (= (select a 0) 1))
+(assert (= b 99))
+(check-sat)
+(get-model)

--- a/tests/regress/iss390_array_const.smt2.gold
+++ b/tests/regress/iss390_array_const.smt2.gold
@@ -1,0 +1,3 @@
+sat
+((define-fun a () (Array Int Int) (store ((as const (Array Int Int)) 2) 0 1))
+ (define-fun b () Int 99))

--- a/tests/regress/iss390_array_define_sort.smt2
+++ b/tests/regress/iss390_array_define_sort.smt2
@@ -1,0 +1,8 @@
+; Issue #390: define-sort macros that expand to an Array sort must
+; still trigger the SMT-LIB store/const rendering in models.
+(set-logic QF_AUFLIA)
+(define-sort A () (Array Int Int))
+(declare-fun a () A)
+(assert (= (select a 0) 1))
+(check-sat)
+(get-model)

--- a/tests/regress/iss390_array_define_sort.smt2.gold
+++ b/tests/regress/iss390_array_define_sort.smt2.gold
@@ -1,0 +1,2 @@
+sat
+((define-fun a () A (store ((as const A) 2) 0 1)))

--- a/tests/regress/iss390_array_mixed.smt2
+++ b/tests/regress/iss390_array_mixed.smt2
@@ -1,0 +1,12 @@
+; Issue #390: regression guard. An Array-declared constant must use
+; store/const form while a real unary function declared in the same
+; problem must keep the (define-fun f ((x!0 K)) V (ite ...)) form.
+(set-logic QF_AUFLIA)
+(declare-fun a () (Array Int Int))
+(declare-fun f (Int) Int)
+(assert (= (select a 0) 1))
+(assert (= (select a 1) 3))
+(assert (= (f 0) 5))
+(assert (= (f 1) 7))
+(check-sat)
+(get-model)

--- a/tests/regress/iss390_array_mixed.smt2.gold
+++ b/tests/regress/iss390_array_mixed.smt2.gold
@@ -1,0 +1,3 @@
+sat
+((define-fun a () (Array Int Int) (store (store ((as const (Array Int Int)) 2) 1 3) 0 1))
+ (define-fun f ((x!0 Int)) Int (ite (= x!0 0) 5 (ite (= x!0 1) 7 4))))

--- a/tests/regress/iss390_array_pushpop.smt2
+++ b/tests/regress/iss390_array_pushpop.smt2
@@ -1,0 +1,14 @@
+; Issue #390: array-constant marker must be dropped on (pop). After
+; popping an Array declaration and re-declaring the same name as a
+; unary function, the model must render the function with its
+; parameters and not as an array constant.
+(set-logic QF_AUFLIA)
+(push 1)
+(declare-fun a () (Array Int Int))
+(assert (= (select a 0) 7))
+(check-sat)
+(pop 1)
+(declare-fun a (Int) Int)
+(assert (= (a 0) 5))
+(check-sat)
+(get-model)

--- a/tests/regress/iss390_array_pushpop.smt2.gold
+++ b/tests/regress/iss390_array_pushpop.smt2.gold
@@ -1,0 +1,3 @@
+sat
+sat
+((define-fun a ((x!0 Int)) Int (ite (= x!0 0) 5 1)))

--- a/tests/regress/iss390_array_pushpop.smt2.options
+++ b/tests/regress/iss390_array_pushpop.smt2.options
@@ -1,0 +1,1 @@
+--incremental

--- a/tests/regress/iss390_array_reset.smt2
+++ b/tests/regress/iss390_array_reset.smt2
@@ -1,0 +1,13 @@
+; Issue #390: (reset-assertions) without global-decls must clear the
+; array-constant marker (yices_reset_tables recycles term ids). After
+; the reset, redeclaring the same name as Int must render as a plain
+; (define-fun a () Int ...) and not as an array constant.
+(set-logic QF_AUFLIA)
+(declare-fun a () (Array Int Int))
+(assert (= (select a 0) 1))
+(check-sat)
+(reset-assertions)
+(declare-fun a () Int)
+(assert (= a 99))
+(check-sat)
+(get-model)

--- a/tests/regress/iss390_array_reset.smt2.gold
+++ b/tests/regress/iss390_array_reset.smt2.gold
@@ -1,0 +1,3 @@
+sat
+sat
+((define-fun a () Int 99))

--- a/tests/regress/iss390_array_reset.smt2.options
+++ b/tests/regress/iss390_array_reset.smt2.options
@@ -1,0 +1,1 @@
+--incremental

--- a/tests/regress/mcsat/arrays/issue613_model_print.smt2.gold
+++ b/tests/regress/mcsat/arrays/issue613_model_print.smt2.gold
@@ -1,5 +1,6 @@
 sat
-((define-fun a ((x!0 Int)) (Array Int Int) (ite (= x!0 1) (store ((as const (Array Int Int)) 2) 7 10) ((as const (Array Int Int)) 0))))
+((define-fun a () (Array Int (Array Int Int))
+   (store ((as const (Array Int (Array Int Int))) ((as const (Array Int Int)) 0)) 1 (store ((as const (Array Int Int)) 2) 7 10))))
 ((a (store ((as const (Array Int (Array Int Int))) ((as const (Array Int Int)) 0)) 1 (store ((as const (Array Int Int)) 2) 7 10))))
 (((select a 1) (store ((as const (Array Int Int)) 2) 7 10)))
 (((select (select a 1) 7) 10))

--- a/tests/regress/wd/example_mdl.smt2.gold
+++ b/tests/regress/wd/example_mdl.smt2.gold
@@ -1,5 +1,5 @@
 sat
-((define-fun arr1 ((x!0 Int)) Bool false)
-  (define-fun arr2 ((x!0 Int)) Bool (ite (= x!0 10) true false)))
+((define-fun arr1 () (Array Int Bool) ((as const (Array Int Bool)) false))
+ (define-fun arr2 () (Array Int Bool) (store ((as const (Array Int Bool)) false) 10 true)))
 ((arr1 ((as const (Array Int Bool)) false))
  (arr2 (store ((as const (Array Int Bool)) false) 10 true)))


### PR DESCRIPTION
## Summary

Fixes the model display part of #390. Symbols declared via the SMT-LIB `Array` sort are now
rendered in `(get-model)` as 0-arity array constants in SMT-LIB form,
e.g.

```smt2
(define-fun a () (Array Int Int)
  (store (store ((as const (Array Int Int)) 4) 2 5) 1 3))
```

instead of the previous, non-SMT-LIB-conformant function form

```smt2
(define-fun a ((x!0 Int)) Int (ite (= x!0 1) 3 (ite (= x!0 2) 5 4)))
```

which has both the wrong arity and the wrong sort relative to the
user's declaration. This is required for the SMT-COMP 2026 Model
Validation Track.

## Root cause

Once interned, Yices' type system represents both

```smt2
(declare-fun a () (Array K V))
(declare-fun f (K) V)
```

as an `UNINTERPRETED_TERM` of internal function type `(-> K V)`, so by
the time [print_smt2_model](cci:1://file:///Users/sgl/git/yices/yices2/src/frontend/smt2/smt2_commands.c:4060:0-4099:1) runs the SMT-LIB sort information is gone.
The fix records the missing bit (*"this name was declared as an
`Array` constant"*) in the SMT2 frontend at parse time and consults it
in the model printer.

## Implementation

Scoped entirely to [/Users/sgl/git/yices/yices2/src/frontend/smt2/](cci:4://file:///Users/sgl/git/yices/yices2/src/frontend/smt2/:0:0-0:0).

- **`smt2_globals_t.array_const_terms`** — new `int_hmap_t` (term id →
  1 marker). Populated in [smt2_declare_fun](cci:1://file:///Users/sgl/git/yices/yices2/src/frontend/smt2/smt2_commands.c:7002:0-7038:1) whenever the declaration
  is 0-arity and the resulting internal Yices type is a unary function
  type. Under SMT-LIB syntax that combination can only come from the
  `Array` sort (directly, via `define-sort`, or nested), so the check
  is both necessary and sufficient. `declare-const` is automatically
  covered because the SMT2 parser reduces it to `SMT2_DECLARE_FUN`.

- **Lifecycle.** Init/delete in [init_smt2_globals](cci:1://file:///Users/sgl/git/yices/yices2/src/frontend/smt2/smt2_commands.c:4676:0-4762:1) /
  [delete_smt2_globals](cci:1://file:///Users/sgl/git/yices/yices2/src/frontend/smt2/smt2_commands.c:4753:0-4811:1). `(pop)` is hooked via [smt2_pop_term_names](cci:1://file:///Users/sgl/git/yices/yices2/src/frontend/smt2/smt2_commands.c:370:0-403:1),
  which now does a guarded `int_hmap_find` → `int_hmap_erase` per
  popped term (most popped names are not arrays, so the lookup avoids
  the cost of a no-op erase and the requirement that the record
  exists). `(reset-assertions)` calls `int_hmap_reset` alongside
  `yices_reset_tables()` only when `!global_decls`, since
  `yices_reset_tables` recycles term ids and stale markers would
  otherwise alias new unrelated terms; with `--global-decls` the map
  is preserved, matching the rest of the reset semantics. `(reset)` is
  covered automatically: [smt2_reset_all](cci:1://file:///Users/sgl/git/yices/yices2/src/frontend/smt2/smt2_commands.c:7206:0-7232:1) destroys and re-inits the
  globals.

- **Printer.** [smt2_pp_def](cci:1://file:///Users/sgl/git/yices/yices2/src/frontend/smt2/smt2_printer.c:755:0-788:1) gains a `bool array_const` parameter.
  When set, the definition is emitted as `(define-fun name () τ
  <value>)` regardless of the value's internal representation, and
  dispatches into the existing [smt2_pp_object_in_def](cci:1://file:///Users/sgl/git/yices/yices2/src/frontend/smt2/smt2_printer.c:626:0-638:1) →
  [smt2_pp_array](cci:1://file:///Users/sgl/git/yices/yices2/src/frontend/smt2/smt2_printer.c:516:0-562:1) / [smt2_pp_array_update](cci:1://file:///Users/sgl/git/yices/yices2/src/frontend/smt2/smt2_printer.c:564:0-612:1) path which already produces
  `store` / `(as const τ)` syntax. [print_smt2_model](cci:1://file:///Users/sgl/git/yices/yices2/src/frontend/smt2/smt2_commands.c:4060:0-4099:1) looks up the
  marker via `int_hmap_find` and threads the flag through.

## Scope

- **In scope:** the SMT-LIB-style model output (`clean_model_format
  == false`), which is the default for the `yices_smt2` CLI binary
  ([smt2_force_smt2_model_format()](cci:1://file:///Users/sgl/git/yices/yices2/src/frontend/smt2/smt2_commands.c:4884:0-4889:1) at startup) and the configuration
  used by SMT-COMP. Library users obtain it the same way.
- **Out of scope:** the Yices-native model format
  (`clean_model_format == true`, `smt2_pp_full_model`) emits
  `(function ...)` / `(default ...)` syntax that is not valid SMT-LIB
  regardless of arrays vs functions. Fixing it requires rewriting that
  printer on top of [smt2_pp_def](cci:1://file:///Users/sgl/git/yices/yices2/src/frontend/smt2/smt2_printer.c:755:0-788:1); tracked for a follow-up.
- **Out of scope:** accepting `(as const (Array K V))` as **input**.
  Issue #390 also asks for that direction; it requires changes to the
  parser and type system that are orthogonal to model output. This PR
  delivers the output direction; input support remains a separate
  feature.

## Manual verification

Confirmed correct rendering on:

- `(declare-fun a () (Array Int Int))`
- `(declare-const a (Array Int Int))`
- `(declare-fun a () (Array Int (Array Int Int)))` (nested)
- `(declare-fun a () (Array (_ BitVec 4) (_ BitVec 4)))`
- `(declare-fun a () (Array Int Real))` (Int → Real coercion in
  `(as const ...)`)
- (define-sort A () (Array Int Int)) + (declare-fun a () A)
- (declare-fun f (Int) (Array Int Int)) (UF with array range —
  array-of-array store/const at each leaf)
- Mixed array constant and plain UF in the same problem (UF must keep
  its ((x!0 K)) V (ite ...) form)
- (push 1) / array decl / (pop 1) / re-declare same name as a
  function (marker must not leak across pop)
- (reset-assertions) / re-declare same name as Int (marker must
  not survive term-id recycling)

## Regression tests

Six new gold-checked tests under [/Users/sgl/git/yices/yices2/tests/regress/](cci:4://file:///Users/sgl/git/yices/yices2/tests/regress/:0:0-0:0), matching the
existing issNNN_* convention:

- [iss390_array_basic.smt2](cci:7://file:///Users/sgl/git/yices/yices2/tests/regress/iss390_array_basic.smt2:0:0-0:0)
- [iss390_array_const.smt2](cci:7://file:///Users/sgl/git/yices/yices2/tests/regress/iss390_array_const.smt2:0:0-0:0)
- [iss390_array_mixed.smt2](cci:7://file:///Users/sgl/git/yices/yices2/tests/regress/iss390_array_mixed.smt2:0:0-0:0)
- [iss390_array_define_sort.smt2](cci:7://file:///Users/sgl/git/yices/yices2/tests/regress/iss390_array_define_sort.smt2:0:0-0:0)
- [iss390_array_pushpop.smt2](cci:7://file:///Users/sgl/git/yices/yices2/tests/regress/iss390_array_pushpop.smt2:0:0-0:0) (--incremental)
- [iss390_array_reset.smt2](cci:7://file:///Users/sgl/git/yices/yices2/tests/regress/iss390_array_reset.smt2:0:0-0:0) (--incremental)

All six pass under [tests/regress/check.sh](cci:7://file:///Users/sgl/git/yices/yices2/tests/regress/check.sh:0:0-0:0).

The full [/Users/sgl/git/yices/yices2/tests/regress](cci:4://file:///Users/sgl/git/yices/yices2/tests/regress:0:0-0:0) suite shows **no new regressions**: the same
245 pre-existing failures are present on master and on this branch
(predominantly wd/, coverage/random/QF_AUFBV/, and mcsat/ cases
that are known-broken before this work).

## Files touched

- [src/frontend/smt2/smt2_commands.h](cci:7://file:///Users/sgl/git/yices/yices2/src/frontend/smt2/smt2_commands.h:0:0-0:0)
- [src/frontend/smt2/smt2_commands.c](cci:7://file:///Users/sgl/git/yices/yices2/src/frontend/smt2/smt2_commands.c:0:0-0:0)
- [src/frontend/smt2/smt2_printer.h](cci:7://file:///Users/sgl/git/yices/yices2/src/frontend/smt2/smt2_printer.h:0:0-0:0)
- [src/frontend/smt2/smt2_printer.c](cci:7://file:///Users/sgl/git/yices/yices2/src/frontend/smt2/smt2_printer.c:0:0-0:0)
- tests/regress/iss390_array_*.smt2{,.gold,.options} (new)