### PR TITLE
mcsat: fall back to model cache when target cache value is infeasible

### DIFF
--- a/src/mcsat/bv/bv_feasible_set_db.c
+++ b/src/mcsat/bv/bv_feasible_set_db.c
@@ -222,16 +222,18 @@ const mcsat_value_t* bv_feasible_set_db_pick_value(bv_feasible_set_db_t* db, var
   term_t x_term = variable_db_get_term(db->ctx->var_db, x);
   uint32_t x_bitsize = term_bitsize(db->ctx->terms, x_term);
 
-  // Check the cached value from the
+  // Check the cached values: the trail returns the cached hints in priority order;
+  // return the first that is in the feasible set.
   const mcsat_trail_t* trail = db->ctx->trail;
-  if (trail_has_cached_value(trail, x)) {
-    const mcsat_value_t* cached_value = trail_get_cached_value(trail, x);
+  const mcsat_value_t* candidates[2];
+  uint32_t num_candidates = trail_get_cached_candidates(trail, x, candidates);
+  for (uint32_t i = 0; i < num_candidates; ++i) {
+    const mcsat_value_t* cached_value = candidates[i];
     if (x_feasible_full) {
       return cached_value;
-    } else {
-      ok = bv_bdd_manager_is_model(db->bddm, x_term, x_feasible_bdd, &cached_value->bv_value);
-      if (ok) { return cached_value; }
     }
+    ok = bv_bdd_manager_is_model(db->bddm, x_term, x_feasible_bdd, &cached_value->bv_value);
+    if (ok) { return cached_value; }
   }
 
   // Initialize the value we're using

--- a/src/mcsat/ff/ff_plugin.c
+++ b/src/mcsat/ff/ff_plugin.c
@@ -784,12 +784,15 @@ void ff_plugin_decide(plugin_t* plugin, variable_t x, trail_token_t* decide_toke
   const mcsat_value_t *x_new = NULL;
   mcsat_value_t x_new_local;
 
-  // see if there is a fitting cached value
-  if (trail_has_cached_value(ff->ctx->trail, x)) {
-    x_new = trail_get_cached_value(ff->ctx->trail, x);
-    assert(x_new->type == VALUE_LIBPOLY);
-    assert(x_new->lp_value.type == LP_VALUE_INTEGER);
-    if (feasible == NULL || lp_feasibility_set_int_contains(feasible, &x_new->lp_value.value.z)) {
+  // see if there is a fitting cached value: the trail returns the cached hints in
+  // priority order; check each against the feasible set and take the first fit.
+  const mcsat_value_t* x_candidates[2];
+  uint32_t x_num_candidates = trail_get_cached_candidates(ff->ctx->trail, x, x_candidates);
+  for (uint32_t i = 0; i < x_num_candidates && !using_cached; ++i) {
+    assert(x_candidates[i]->type == VALUE_LIBPOLY);
+    assert(x_candidates[i]->lp_value.type == LP_VALUE_INTEGER);
+    if (feasible == NULL || lp_feasibility_set_int_contains(feasible, &x_candidates[i]->lp_value.value.z)) {
+      x_new = x_candidates[i];
       using_cached = true;
     }
   }

--- a/src/mcsat/na/na_plugin.c
+++ b/src/mcsat/na/na_plugin.c
@@ -1110,12 +1110,15 @@ void na_plugin_decide(plugin_t* plugin, variable_t x, trail_token_t* decide_toke
   lp_value_construct(&x_new_lpvalue, LP_VALUE_RATIONAL, &x_value_default);
   lp_rational_destruct(&x_value_default);
 
-  // See if the cached value fits
+  // See if a cached value fits: the trail returns the cached hints in priority
+  // order; check each against the feasible set and take the first that fits.
   bool using_cached = false;
   const mcsat_value_t* x_cached_value = NULL;
-  if (trail_has_cached_value(na->ctx->trail, x)) {
-    x_cached_value = trail_get_cached_value(na->ctx->trail, x);
-    if (feasible == NULL || lp_feasibility_set_contains(feasible, &x_cached_value->lp_value)) {
+  const mcsat_value_t* x_candidates[2];
+  uint32_t x_num_candidates = trail_get_cached_candidates(na->ctx->trail, x, x_candidates);
+  for (uint32_t i = 0; i < x_num_candidates && !using_cached; ++i) {
+    if (feasible == NULL || lp_feasibility_set_contains(feasible, &x_candidates[i]->lp_value)) {
+      x_cached_value = x_candidates[i];
       using_cached = true;
     }
   }

--- a/src/mcsat/trail.h
+++ b/src/mcsat/trail.h
@@ -222,6 +222,29 @@ const mcsat_value_t* trail_get_cached_value(const mcsat_trail_t* trail, variable
   }
 }
 
+/*
+ * Collect the cached decision-value hints for an unassigned variable, in priority
+ * order, into out[]. Returns the number of distinct hints (0, 1, or 2): the
+ * higher-priority tier-1 value (target cache) first, then the tier-2 value (model
+ * cache) when it is present and not identical to the tier-1 value. Each value is
+ * only a hint: the caller must still check it against the variable's feasible set
+ * before deciding on it.
+ */
+static inline
+uint32_t trail_get_cached_candidates(const mcsat_trail_t* trail, variable_t var, const mcsat_value_t* out[2]) {
+  assert(!trail_has_value(trail, var));
+  uint32_t n = 0;
+  const mcsat_value_t* tier1 = mcsat_model_get_value(&trail->target_cache, var);
+  const mcsat_value_t* tier2 = mcsat_model_get_value(&trail->model, var);
+  if (tier1->type != VALUE_NONE) {
+    out[n++] = tier1;
+  }
+  if (tier2->type != VALUE_NONE && (n == 0 || !mcsat_value_eq(tier2, out[0]))) {
+    out[n++] = tier2;
+  }
+  return n;
+}
+
 /** Get the value timestamp of the variable */
 static inline
 uint32_t trail_get_value_timestamp(const mcsat_trail_t* trail, variable_t var) {

--- a/src/mcsat/uf/uf_plugin.c
+++ b/src/mcsat/uf/uf_plugin.c
@@ -449,17 +449,32 @@ void uf_plugin_decide(plugin_t* plugin, variable_t x, trail_token_t* decide, boo
 
   assert(eq_graph_is_trail_propagated(&uf->eq_graph));
 
-  // Get the cached value
-  const mcsat_value_t* x_cached_value = NULL;
-  if (trail_has_cached_value(uf->ctx->trail, x)) {
-    x_cached_value = trail_get_cached_value(uf->ctx->trail, x);
-  }
+  // Cached values to try, in priority order (only hints; each is checked against
+  // the forbidden set via eq_graph_get_forbidden).
+  const mcsat_value_t* x_candidates[2] = { NULL, NULL };
+  uint32_t x_num_candidates = trail_get_cached_candidates(uf->ctx->trail, x, x_candidates);
 
   // Pick a value not in the forbidden set
   term_t x_term = variable_db_get_term(uf->ctx->var_db, x);
   pvector_t forbidden;
   init_pvector(&forbidden, 0);
-  bool cache_ok = eq_graph_get_forbidden(&uf->eq_graph, x_term, &forbidden, x_cached_value);
+  // Build the forbidden list while testing the first candidate (the list does not
+  // depend on the candidate, so pass NULL when there is none); then test any
+  // remaining candidates against the already-built list (values == NULL).
+  const mcsat_value_t* x_cached_value = NULL;
+  bool cache_ok = eq_graph_get_forbidden(&uf->eq_graph, x_term, &forbidden,
+                                         x_num_candidates > 0 ? x_candidates[0] : NULL);
+  if (cache_ok) {
+    x_cached_value = x_candidates[0];
+  } else {
+    for (uint32_t i = 1; i < x_num_candidates; ++i) {
+      if (eq_graph_get_forbidden(&uf->eq_graph, x_term, NULL, x_candidates[i])) {
+        x_cached_value = x_candidates[i];
+        cache_ok = true;
+        break;
+      }
+    }
+  }
   if (ctx_trace_enabled(uf->ctx, "uf_plugin::decide")) {
     ctx_trace_printf(uf->ctx, "picking !=");
     uint32_t i;

--- a/src/mcsat/value.c
+++ b/src/mcsat/value.c
@@ -274,7 +274,7 @@ bool mcsat_value_eq(const mcsat_value_t* v1, const mcsat_value_t* v2) {
     if (v2->type == VALUE_LIBPOLY) {
       return lp_value_cmp(&v1->lp_value, &v2->lp_value) == 0;
     } else {
-      assert(v1->type == VALUE_RATIONAL);
+      assert(v2->type == VALUE_RATIONAL);
       mpq_t v2_mpq;
       mpq_init(v2_mpq);
       q_get_mpq((rational_t*)&v2->q, v2_mpq);


### PR DESCRIPTION
When deciding a value, the feasibility-aware plugins (na, ff, bv, uf) used a single cached hint (target cache preferred, else model cache). If that value was infeasible they went straight to a fresh pick, discarding the model cache's saved phase.

Try both cached tiers in priority order instead: tier 1 (target cache), then tier 2 (model cache), each checked against the variable's feasible set, before falling back to a fresh pick. The new behavior only fires when the target value is present but infeasible and the model value is present, feasible, and different - every other path is unchanged.

Add trail_get_cached_candidates() to own the priority ordering, NULL-stripping, and dedup (skip tier 2 when identical to tier 1) in one place; each plugin's decide path is now a plain loop over the returned candidates with only its own feasibility predicate. bool_plugin keeps the original combined getter (it has no feasible set).

Also fix a latent copy-paste assert in mcsat_value_eq (VALUE_LIBPOLY vs VALUE_RATIONAL comparison asserted v1->type instead of v2->type).

Full regression suite: 1726/1726 pass.