### PR TITLE
Small fixes: mcsat null-pointer UB and generalize_model_array return type

### DIFF
--- a/src/api/yices_api.c
+++ b/src/api/yices_api.c
@@ -13195,20 +13195,20 @@ int32_t _o_yices_generalize_model(model_t *mdl, term_t t, uint32_t nelims, const
 /*
  * Same thing for a conjunction of formulas a[0 ... n-1]
  */
-EXPORTED term_t yices_generalize_model_array(model_t *mdl, uint32_t n, const term_t a[], uint32_t nelims, const term_t elim[],
-					     yices_gen_mode_t mode, term_vector_t *v) {
-  MT_PROTECT(term_t,  __yices_globals.lock, _o_yices_generalize_model_array(mdl, n, a, nelims, elim, mode, v));
+EXPORTED int32_t yices_generalize_model_array(model_t *mdl, uint32_t n, const term_t a[], uint32_t nelims, const term_t elim[],
+					      yices_gen_mode_t mode, term_vector_t *v) {
+  MT_PROTECT(int32_t,  __yices_globals.lock, _o_yices_generalize_model_array(mdl, n, a, nelims, elim, mode, v));
 }
 
-term_t _o_yices_generalize_model_array(model_t *mdl, uint32_t n, const term_t a[], uint32_t nelims, const term_t elim[],
-					     yices_gen_mode_t mode, term_vector_t *v) {
+int32_t _o_yices_generalize_model_array(model_t *mdl, uint32_t n, const term_t a[], uint32_t nelims, const term_t elim[],
+					yices_gen_mode_t mode, term_vector_t *v) {
   int32_t code;
   int32_t extra_error;
 
   if (! check_good_terms(__yices_globals.manager, n, a) ||
       ! check_boolean_args(__yices_globals.manager, n, a) ||
       ! check_elim_vars(__yices_globals.manager, nelims, elim)) {
-    return NULL_TERM;
+    return -1;
   }
 
   extra_error = 0;

--- a/src/api/yices_api_lock_free.h
+++ b/src/api/yices_api_lock_free.h
@@ -828,8 +828,8 @@ extern int32_t _o_yices_generalize_model(model_t *mdl, term_t t, uint32_t nelims
 				  yices_gen_mode_t mode, term_vector_t *v);
 
 
-extern term_t _o_yices_generalize_model_array(model_t *mdl, uint32_t n, const term_t a[], uint32_t nelims, const term_t elim[],
-				       yices_gen_mode_t mode, term_vector_t *v);
+extern int32_t _o_yices_generalize_model_array(model_t *mdl, uint32_t n, const term_t a[], uint32_t nelims, const term_t elim[],
+					       yices_gen_mode_t mode, term_vector_t *v);
 
 
 /*************************

--- a/src/mcsat/solver.c
+++ b/src/mcsat/solver.c
@@ -3053,7 +3053,7 @@ void mcsat_solve(mcsat_solver_t* mcsat, const param_t *params, model_t* mdl, uin
     }
 
     // Should we decide on an assumption
-    bool assumption_decided = mcsat_decide_assumption(mcsat, model_get_vtbl(mdl));
+    bool assumption_decided = mcsat_decide_assumption(mcsat, mdl != NULL ? model_get_vtbl(mdl) : NULL);
     if (assumption_decided) {
       continue;
     }


### PR DESCRIPTION
Two small, independent fixes.

## 1. mcsat: avoid UB null pointer member access on plain check

[mcsat_solve()](cci:1://file:///Users/sgl/git/yices/yices2/src/mcsat/solver.c:2941:0-3128:1) is called with `mdl == NULL` on a plain check (no model
assumptions — see `_o_call_mcsat_solver` in [context_solver.c](cci:7://file:///Users/sgl/git/yices/yices2/src/context/context_solver.c:0:0-0:0)). The
search loop unconditionally evaluated [model_get_vtbl(mdl)](cci:1://file:///Users/sgl/git/yices/yices2/src/model/models.h:86:0-91:1), which
expands to `&mdl->vtbl`. With `mdl == NULL` this forms a member access
within a null pointer — undefined behavior flagged by UBSan
(`model/models.h:91`).

Fix: pass the vtbl through only when a model is present:

    mcsat_decide_assumption(mcsat, mdl != NULL ? model_get_vtbl(mdl) : NULL);

The `vtbl` is only consumed inside [mcsat_decide_assumption](cci:1://file:///Users/sgl/git/yices/yices2/src/mcsat/solver.c:2459:0-2550:1)'s loop over
assumption variables, which is empty when there are no assumptions. No
functional change; just removes the UB.

## 2. api: fix [yices_generalize_model_array](cci:1://file:///Users/sgl/git/yices/yices2/src/api/yices_api.c:13194:0-13200:1) return type

The public header ([yices.h](cci:7://file:///Users/sgl/git/yices/yices2/src/include/yices.h:0:0-0:0)) declares
[yices_generalize_model_array](cci:1://file:///Users/sgl/git/yices/yices2/src/api/yices_api.c:13194:0-13200:1) as returning `int32_t`, but the
implementation defined it as `term_t` and returned `NULL_TERM` on error.
The function actually produces a status code (`0` on success, `-1` on
error), matching its sibling [yices_generalize_model](cci:1://file:///Users/sgl/git/yices/yices2/src/api/yices_api.c:13141:0-13156:1).

Fix: change the `EXPORTED` definition, the `_o_` definition, and the
lock-free header prototype to `int32_t`, and return `-1` on the
argument-check failure path. Since `term_t` is a typedef for `int32_t`,
this is a source-level correctness fix with no ABI change.