### PR TITLE
ci: upload coverage once per commit to avoid Coveralls 422

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,14 @@ jobs:
           REGRESS_EXCLUDE_FILTER: ${{ matrix.mode == 'gcov' && contains(matrix.config-opt, '--enable-thread-safety') && contains(matrix.config-opt, '--enable-mcsat') && 'iss517.smt2$' || '' }}
         with:
           mode: ${{ matrix.mode }}
+      # Coverage is uploaded once per commit. The push build uploads it only
+      # for master (the baseline); pull-request builds upload it for PRs. This
+      # avoids two runs racing to close the same Coveralls build for one commit.
       - name: Coverage
-        if: matrix.mode == 'gcov' && matrix.config-opt == '--enable-mcsat'
+        if: matrix.mode == 'gcov' && matrix.config-opt == '--enable-mcsat' && github.ref == 'refs/heads/master'
         uses: ./.github/actions/coverage
       - name: Coveralls
-        if: matrix.mode == 'gcov' && matrix.config-opt == '--enable-mcsat'
+        if: matrix.mode == 'gcov' && matrix.config-opt == '--enable-mcsat' && github.ref == 'refs/heads/master'
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pushing to a PR branch triggers both build-push (on.push.branches: '**') and build-pr, and both ran the gcov Coveralls upload for the same commit SHA. Coveralls keys a build by commit; the first uploader closes it and the second is rejected with "422 Can't add a job to a build that is already closed", turning CI red on a race.

Gate the push build's coverage upload to master only, so the master baseline comes from build-push and PR coverage comes from build-pr. Each commit now has exactly one Coveralls upload. Coveralls stays blocking, so genuine coverage regressions still fail CI.