### PR TITLE
New Mcsat reduce

### DIFF
--- a/src/mcsat/bool/bool_plugin.c
+++ b/src/mcsat/bool/bool_plugin.c
@@ -52,8 +52,11 @@ typedef struct {
   /** Lemmas, so that we can potentially remove them */
   ivector_t lemmas;
 
-  /** Limit on lemma count before we do compaction */
-  uint32_t lemmas_limit;
+  /** Cumulative number of conflicts (drives the conflict-based reduce trigger) */
+  uint64_t conflicts;
+
+  /** Next conflict count at which to reduce the lemma database */
+  uint64_t reduce_threshold;
 
   /** Clauses to re-check for propagations. */
   ivector_t clauses_to_repropagate;
@@ -82,8 +85,8 @@ typedef struct {
   /** GC info for clause removal */
   gc_info_t gc_clauses;
 
-  /** GC round */
-  uint32_t gc_round;
+  /** Whether to keep unsatisfied binary clauses this GC (alternates each GC) */
+  bool gc_keep_binary;
 
   struct {
 
@@ -94,10 +97,10 @@ typedef struct {
     /** Limit for when to scale down */
     float clause_score_limit;
 
-    /** Limit on lemma clauses before we ask for gc */
-    uint32_t lemma_limit_init;
-    /** Increase of the lemma limit after gc */
-    float lemma_limit_interval;
+    /** Initial conflict count at which to reduce the lemma database */
+    uint32_t reduce_init_threshold;
+    /** Reduce interval multiplier (next threshold = conflicts + this * sqrt(conflicts)) */
+    uint32_t reduce_interval;
 
     /** bump factor for bool vars -- geq 1. Higher number means more weightage **/
     uint32_t bool_var_bump_factor;
@@ -131,9 +134,9 @@ void bool_plugin_heuristics_init(bool_plugin_t* bp) {
   bp->heuristic_params.clause_score_decay_factor = 0.999;
   bp->heuristic_params.clause_score_limit = 1e20;
 
-  // Clause database compact
-  bp->heuristic_params.lemma_limit_init = 1000;
-  bp->heuristic_params.lemma_limit_interval = 100;
+  // Clause database reduction (conflict-based schedule, cf. smt_core)
+  bp->heuristic_params.reduce_init_threshold = 300;
+  bp->heuristic_params.reduce_interval = 25;
 
   // Bool var scoring
   bp->heuristic_params.bool_var_bump_factor = 20;
@@ -172,6 +175,13 @@ void bool_plugin_construct(plugin_t* plugin, plugin_context_t* ctx) {
 
   bool_plugin_stats_init(bp);
   bool_plugin_heuristics_init(bp);
+
+  // Conflict-based reduce schedule. Conflicts are counted cumulatively here so
+  // bp->conflicts matches the core solver's conflict count (mcsat::conflicts);
+  // only the schedule (threshold/toggle) is reset per search, not the count.
+  bp->conflicts = 0;
+  bp->reduce_threshold = bp->heuristic_params.reduce_init_threshold;
+  bp->gc_keep_binary = false;
 }
 
 static
@@ -913,8 +923,9 @@ void bool_plugin_gc_mark(plugin_t* plugin, gc_info_t* gc_vars) {
       gc_info_mark(&bp->gc_clauses, clause_ref);
     }
 
-    // keep binary clauses for a little longer -- one more round
-    for (i = 0; bp->gc_round % 2 != 0 && i < bp->lemmas.size; ++ i) {
+    // keep binary clauses for a little longer -- one more round (alternate each GC)
+    bp->gc_keep_binary = !bp->gc_keep_binary;
+    for (i = 0; bp->gc_keep_binary && i < bp->lemmas.size; ++ i) {
       clause_ref = bp->lemmas.data[i];
       assert(clause_db_is_clause(db, clause_ref, true));
       c = clause_db_get_clause(&bp->clause_db, clause_ref);
@@ -1013,20 +1024,26 @@ void bool_plugin_event_notify(plugin_t* plugin, plugin_notify_kind_t kind) {
 
   switch (kind) {
   case MCSAT_SOLVER_START:
-    // Re-initialize the heuristics
-    bp->lemmas_limit = bp->heuristic_params.lemma_limit_init;
-    bp->gc_round = 0;
+    // Re-initialize the reduce schedule for this search. bp->conflicts is
+    // cumulative (it tracks the core solver's conflict count), so anchor the
+    // first threshold at the current conflict count + the initial offset
+    // (cf. CaDiCaL's lim.reduce = conflicts + reduceinit).
+    bp->reduce_threshold = bp->conflicts + bp->heuristic_params.reduce_init_threshold;
+    bp->gc_keep_binary = false;
     break;
   case MCSAT_SOLVER_RESTART:
-    // Check if clause compaction needed
-    if (bp->lemmas.size > bp->lemmas_limit) {
+    // Reduce the lemma database on a conflict-based schedule (cf. smt_core):
+    // when the conflict count reaches the threshold, schedule a GC and set the
+    // next threshold to conflicts + reduce_interval * sqrt(conflicts).
+    if (bp->conflicts >= bp->reduce_threshold) {
       bp->ctx->request_gc(bp->ctx);
-      bp->gc_round++;
-      bp->lemmas_limit += bp->heuristic_params.lemma_limit_interval * sqrt(bp->gc_round);
+      bp->reduce_threshold = bp->conflicts +
+        (uint64_t) (bp->heuristic_params.reduce_interval * sqrt((double) bp->conflicts));
     }
     break;
   case MCSAT_SOLVER_CONFLICT:
-    // Decay the scores each conflict
+    // Count conflicts and decay the scores each conflict
+    bp->conflicts ++;
     bool_plugin_decay_clause_scores(bp);
     break;
   case MCSAT_SOLVER_POP:

--- a/src/mcsat/bool/bool_plugin.c
+++ b/src/mcsat/bool/bool_plugin.c
@@ -58,6 +58,13 @@ typedef struct {
   /** Next conflict count at which to reduce the lemma database */
   uint64_t reduce_threshold;
 
+  /**
+   * Whether the next GC was requested by this plugin's reduce schedule.
+   * The 'used' protection counters decay only on such GCs, not on GCs
+   * triggered for other reasons (e.g. the GC on every pop).
+   */
+  bool reduce_requested;
+
   /** Clauses to re-check for propagations. */
   ivector_t clauses_to_repropagate;
 
@@ -84,9 +91,6 @@ typedef struct {
 
   /** GC info for clause removal */
   gc_info_t gc_clauses;
-
-  /** Whether to keep unsatisfied binary clauses this GC (alternates each GC) */
-  bool gc_keep_binary;
 
   struct {
 
@@ -178,10 +182,10 @@ void bool_plugin_construct(plugin_t* plugin, plugin_context_t* ctx) {
 
   // Conflict-based reduce schedule. Conflicts are counted cumulatively here so
   // bp->conflicts matches the core solver's conflict count (mcsat::conflicts);
-  // only the schedule (threshold/toggle) is reset per search, not the count.
+  // only the schedule (threshold) is reset per search, not the count.
   bp->conflicts = 0;
   bp->reduce_threshold = bp->heuristic_params.reduce_init_threshold;
-  bp->gc_keep_binary = false;
+  bp->reduce_requested = false;
 }
 
 static
@@ -427,6 +431,8 @@ void bool_plugin_bump_clause(bool_plugin_t* bp, const mcsat_clause_t* clause) {
   if (tag->type == CLAUSE_LEMMA) {
     // Bump
     tag->score += bp->heuristic_params.clause_score_bump_factor;
+    // Used in conflict analysis: protect from the next GC round(s)
+    tag->used = clause_used_init(clause->size);
     // If over the limit, normalize
     if (tag->score > bp->heuristic_params.clause_score_limit) {
       bool_plugin_rescale_clause_scores(bp);
@@ -923,19 +929,30 @@ void bool_plugin_gc_mark(plugin_t* plugin, gc_info_t* gc_vars) {
       gc_info_mark(&bp->gc_clauses, clause_ref);
     }
 
-    // keep binary clauses for a little longer -- one more round (alternate each GC)
-    bp->gc_keep_binary = !bp->gc_keep_binary;
-    for (i = 0; bp->gc_keep_binary && i < bp->lemmas.size; ++ i) {
+    // Keep clauses recently created or resolved in conflict analysis
+    // (cf. smt_core). The protection decays only on reduce GCs (the ones
+    // this plugin scheduled), not on GCs triggered for other reasons.
+    // Binary clauses start higher, so they get an extra reduce round.
+    for (i = 0; i < bp->lemmas.size; ++ i) {
       clause_ref = bp->lemmas.data[i];
       assert(clause_db_is_clause(db, clause_ref, true));
-      c = clause_db_get_clause(&bp->clause_db, clause_ref);
-      if (c->size == 2) {
-        if (!literal_is_true(c->literals[0], trail) &&
-            !literal_is_true(c->literals[1], trail)) {
-          gc_info_mark(&bp->gc_clauses, clause_ref);
+      c_tag = clause_db_get_tag(db, clause_ref);
+      if (c_tag->used > 0) {
+        if (bp->reduce_requested) {
+          c_tag->used --;
         }
+        // no protection for binary clauses with a satisfied literal: GC
+        // runs at base level, so they are permanently satisfied
+        c = clause_db_get_clause(db, clause_ref);
+        if (c->size == 2 &&
+            (literal_is_true(c->literals[0], trail) ||
+             literal_is_true(c->literals[1], trail))) {
+          continue;
+        }
+        gc_info_mark(&bp->gc_clauses, clause_ref);
       }
     }
+    bp->reduce_requested = false;
   }
 
   // Mark all the CNF definitions
@@ -1029,7 +1046,6 @@ void bool_plugin_event_notify(plugin_t* plugin, plugin_notify_kind_t kind) {
     // first threshold at the current conflict count + the initial offset
     // (cf. CaDiCaL's lim.reduce = conflicts + reduceinit).
     bp->reduce_threshold = bp->conflicts + bp->heuristic_params.reduce_init_threshold;
-    bp->gc_keep_binary = false;
     break;
   case MCSAT_SOLVER_RESTART:
     // Reduce the lemma database on a conflict-based schedule (cf. smt_core):
@@ -1037,6 +1053,7 @@ void bool_plugin_event_notify(plugin_t* plugin, plugin_notify_kind_t kind) {
     // next threshold to conflicts + reduce_interval * sqrt(conflicts).
     if (bp->conflicts >= bp->reduce_threshold) {
       bp->ctx->request_gc(bp->ctx);
+      bp->reduce_requested = true;
       bp->reduce_threshold = bp->conflicts +
         (uint64_t) (bp->heuristic_params.reduce_interval * sqrt((double) bp->conflicts));
     }

--- a/src/mcsat/bool/bool_plugin.c
+++ b/src/mcsat/bool/bool_plugin.c
@@ -1048,20 +1048,23 @@ void bool_plugin_event_notify(plugin_t* plugin, plugin_notify_kind_t kind) {
     bp->reduce_threshold = bp->conflicts + bp->heuristic_params.reduce_init_threshold;
     break;
   case MCSAT_SOLVER_RESTART:
+    // Nothing to do: the reduce schedule is driven by MCSAT_SOLVER_CONFLICT
+    break;
+  case MCSAT_SOLVER_CONFLICT:
+    // Count conflicts and decay the scores each conflict
+    bp->conflicts ++;
+    bool_plugin_decay_clause_scores(bp);
     // Reduce the lemma database on a conflict-based schedule (cf. smt_core):
-    // when the conflict count reaches the threshold, schedule a GC and set the
-    // next threshold to conflicts + reduce_interval * sqrt(conflicts).
+    // when the conflict count reaches the threshold, request a GC and set the
+    // next threshold to conflicts + reduce_interval * sqrt(conflicts). The
+    // solver runs the GC at base level, right after the next restart (a
+    // pending GC forces a full restart, even with partial restarts enabled).
     if (bp->conflicts >= bp->reduce_threshold) {
       bp->ctx->request_gc(bp->ctx);
       bp->reduce_requested = true;
       bp->reduce_threshold = bp->conflicts +
         (uint64_t) (bp->heuristic_params.reduce_interval * sqrt((double) bp->conflicts));
     }
-    break;
-  case MCSAT_SOLVER_CONFLICT:
-    // Count conflicts and decay the scores each conflict
-    bp->conflicts ++;
-    bool_plugin_decay_clause_scores(bp);
     break;
   case MCSAT_SOLVER_POP:
     // Remove all learnt clauses above base level, regular clauses will be

--- a/src/mcsat/bool/bool_plugin.c
+++ b/src/mcsat/bool/bool_plugin.c
@@ -885,6 +885,20 @@ bool bool_plugin_clause_compare_for_removal(void *data, clause_ref_t c1, clause_
   return c1_tag->score > c2_tag->score;
 }
 
+/**
+ * True if the clause is binary with a satisfied literal. GC runs at base
+ * level, so such a clause is permanently satisfied and not worth keeping
+ * (unless it is the reason of a propagation). Binary clauses only: they
+ * are the ones given extra retention (cf. clause_used_init), and the
+ * check is two literal lookups instead of a full clause scan.
+ */
+static inline
+bool bool_plugin_binary_clause_is_true(const mcsat_clause_t* c, const mcsat_trail_t* trail) {
+  return c->size == 2 &&
+    (literal_is_true(c->literals[0], trail) ||
+     literal_is_true(c->literals[1], trail));
+}
+
 void bool_plugin_gc_mark(plugin_t* plugin, gc_info_t* gc_vars) {
 
   bool_plugin_t* bp = (bool_plugin_t*) plugin;
@@ -919,6 +933,11 @@ void bool_plugin_gc_mark(plugin_t* plugin, gc_info_t* gc_vars) {
         // since the clauses are sorted according to their scores, we break here
         break;
       }
+      // don't keep binary clauses with a satisfied literal
+      c = clause_db_get_clause(db, clause_ref);
+      if (bool_plugin_binary_clause_is_true(c, trail)) {
+        continue;
+      }
       gc_info_mark(&bp->gc_clauses, clause_ref);
     }
 
@@ -941,12 +960,9 @@ void bool_plugin_gc_mark(plugin_t* plugin, gc_info_t* gc_vars) {
         if (bp->reduce_requested) {
           c_tag->used --;
         }
-        // no protection for binary clauses with a satisfied literal: GC
-        // runs at base level, so they are permanently satisfied
+        // no protection for binary clauses with a satisfied literal
         c = clause_db_get_clause(db, clause_ref);
-        if (c->size == 2 &&
-            (literal_is_true(c->literals[0], trail) ||
-             literal_is_true(c->literals[1], trail))) {
+        if (bool_plugin_binary_clause_is_true(c, trail)) {
           continue;
         }
         gc_info_mark(&bp->gc_clauses, clause_ref);

--- a/src/mcsat/bool/clause_db.c
+++ b/src/mcsat/bool/clause_db.c
@@ -182,6 +182,9 @@ clause_ref_t clause_db_new_clause(clause_db_t* db, const mcsat_literal_t* litera
   clause_size = clause_size_in_bytes(size);
   clause_memory = allocate(&clause_size, &db->memory, &db->size, &db->capacity);
 
+  // Lemmas start protected so they survive the GC round(s) following their creation
+  tag.used = tag.type == CLAUSE_LEMMA ? clause_used_init(size) : 0;
+
   // Construct the clause and tag it
   clause_construct(&clause_memory->clause, literals, size);
   clause_memory->tag = tag;

--- a/src/mcsat/bool/clause_db.h
+++ b/src/mcsat/bool/clause_db.h
@@ -55,7 +55,24 @@ typedef struct {
     float score;
   };
 
+  /**
+   * Reduce-protection counter for lemma clauses (CaDiCaL-style "used
+   * recently" flag, cf. smt_core). Set when the clause is created or
+   * resolved in conflict analysis, decremented on each GC; the clause is
+   * protected from deletion while > 0.
+   */
+  uint8_t used;
+
 } mcsat_clause_tag_t;
+
+/**
+ * Reduce protection given to a lemma clause when it is created or resolved
+ * in conflict analysis. Binary clauses get one extra GC round of protection
+ * (this subsumes the old keep-binary-clauses-every-other-GC heuristic).
+ */
+static inline uint8_t clause_used_init(uint32_t clause_size) {
+  return clause_size == 2 ? 2 : 1;
+}
 
 /**
  * A tagged clause is a clause with additional information. For definitional

--- a/src/mcsat/plugin.h
+++ b/src/mcsat/plugin.h
@@ -95,7 +95,11 @@ struct plugin_context_s {
   /** Request a restart */
   void (*request_restart) (plugin_context_t* self);
 
-  /** Request garbage collection */
+  /**
+   * Request garbage collection. The GC runs at base level, right after the
+   * next full restart (a pending GC forces the next restart to be full,
+   * even when partial restarts are enabled).
+   */
   void (*request_gc) (plugin_context_t* self);
 
   /** Request decision calls for a specific type */

--- a/src/mcsat/solver.c
+++ b/src/mcsat/solver.c
@@ -243,7 +243,11 @@ struct mcsat_solver_s {
   /** The queue for variable decisions */
   var_queue_t var_queue;
 
-  /** All pending requests */
+  /**
+   * All pending requests. Note: gc_calls can stay set while
+   * pending_requests is false — a GC is deferred until right after a full
+   * restart, and the next restart request triggers its processing.
+   */
   struct {
     bool restart;
     bool gc_calls;
@@ -1521,6 +1525,7 @@ void mcsat_process_requests(mcsat_solver_t* mcsat) {
   if (mcsat->pending_requests) {
 
     // Restarts
+    bool full_restart = false;
     if (mcsat->pending_requests_all.restart) {
       // save target cache before restart
       trail_update_extra_cache(mcsat->trail);
@@ -1532,8 +1537,10 @@ void mcsat_process_requests(mcsat_solver_t* mcsat) {
       // Determine the backtrack level for restart:
       // If partial_restart is enabled, use mcsat_partial_restart_level to compute the level.
       // Otherwise, perform a full restart by backtracking to the base level.
+      // A pending GC (clause-database reduction) forces a full restart: the
+      // GC must run at base level.
       uint32_t backtrack_level = mcsat->trail->decision_level_base;
-      if (mcsat->ctx->mcsat_options.partial_restart) {
+      if (mcsat->ctx->mcsat_options.partial_restart && !mcsat->pending_requests_all.gc_calls) {
         backtrack_level = mcsat_partial_restart_level(mcsat);
       }
       if (backtrack_level == mcsat->trail->decision_level_base) {
@@ -1544,6 +1551,7 @@ void mcsat_process_requests(mcsat_solver_t* mcsat) {
       mcsat->pending_requests_all.restart = false;
       // notify if backtracked to base level
       if (backtrack_level == mcsat->trail->decision_level_base) {
+        full_restart = true;
         (*mcsat->solver_stats.restarts) ++;
         mcsat_notify_plugins(mcsat, MCSAT_SOLVER_RESTART);
       } else {
@@ -1551,8 +1559,10 @@ void mcsat_process_requests(mcsat_solver_t* mcsat) {
       }
     }
 
-    // GC
-    if (mcsat->pending_requests_all.gc_calls) {
+    // GC -- only right after a full restart, when the solver is in a
+    // quiescent state at base level. A pending GC forces the next restart
+    // to be full (see above), so the GC is never deferred for long.
+    if (mcsat->pending_requests_all.gc_calls && full_restart) {
       if (trace_enabled(mcsat->ctx->trace, "mcsat")) {
         mcsat_trace_printf(mcsat->ctx->trace, "garbage collection\n");
       }
@@ -1568,7 +1578,9 @@ void mcsat_process_requests(mcsat_solver_t* mcsat) {
       (*mcsat->solver_stats.recaches) ++;
     }
 
-    // All services
+    // All services done. A deferred GC stays recorded in
+    // pending_requests_all.gc_calls; the next restart request triggers
+    // its processing.
     mcsat->pending_requests = false;
   }
 }


### PR DESCRIPTION
MCSAT counterpart of #636: replace the bool plugin's learned-clause
  reduction with a conflict-based schedule and CaDiCaL-style "used"
  protection.

  ## Changes
  
  **Conflict-based reduce schedule** (444c86ce): the lemma database is
  reduced when the cumulative conflict count reaches a threshold, starting
  at 300, with the next threshold set to `conflicts + 25 * sqrt(conflicts)`
  — same schedule and defaults as #636. This replaces the old trigger
  (lemma count above a growing limit).

  **"Used" protection** (5206818e): each lemma carries a counter in its
  clause tag; a lemma is protected from deletion while the counter is
  positive. The counter is set at creation and re-armed whenever the lemma
  is resolved in conflict analysis (conflict clause or propagation reason,
  alongside the existing score bump), and decremented only on reduce GCs —
  not on GCs triggered for other reasons (e.g. the GC on every pop), so
  protection lasts for actual reduce rounds. Binary clauses get a counter
  of 2 (one extra reduce round), which subsumes the old
  keep-binary-clauses-every-other-GC heuristic; its removal rule is
  preserved (a binary clause with a satisfied literal gets no protection,
  since GC runs at base level where that satisfaction is permanent).

  **Reduce works under partial restarts** (cec74d82): the reduce trigger is
  evaluated at each conflict instead of in the restart notification (which
  partial restarts never emit). A pending GC forces the next restart to be
  full, and the GC runs right after it — at base level in a quiescent
  state, the same point where GCs ran before.

  ## Differences from #636
  
  - Fresh lemmas start protected (`used = 1`, binary `2`) rather than
    unprotected: the bool plugin has no creation-time score bump, so a new
    lemma has score 0 and would otherwise be first in line for deletion.
  - The clause tag grows 12 → 16 bytes per clause; unlike
    `learned_clause_t` in smt_core, the tag had no free padding.
  - The schedule parameters stay internal to the plugin (not wired to the
    `r-initial-threshold` / `r-interval` API parameters).

  ## Testing
  
  - `mcsat-check`: 696/696 pass (debug build, asserts on).
  - Random 3-SAT stress instance (~18k conflicts): reduce GCs fire exactly
    on the predicted sqrt schedule; with partial restarts force-enabled
    (1010 partial restarts), all reduce GCs still execute on schedule —
    previously none would.
