### PR TITLE
ci: harden Coveralls upload and bump actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     name: ${{ matrix.os }}|${{ matrix.mode }}|${{ matrix.config-opt }}|${{ matrix.env }} (push)
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
       - name: Build
@@ -61,7 +61,7 @@ jobs:
         uses: ./.github/actions/coverage
       - name: Coveralls
         if: matrix.mode == 'gcov' && matrix.config-opt == '--enable-mcsat' && github.ref == 'refs/heads/master'
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: 'coverage.info'
@@ -107,7 +107,7 @@ jobs:
     name: ${{ matrix.os }}|${{ matrix.mode }}|${{ matrix.config-opt }}|${{ matrix.env }} (pr)
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Dependencies
         uses: ./.github/actions/install-dependencies
       - name: Build
@@ -128,7 +128,7 @@ jobs:
         uses: ./.github/actions/coverage
       - name: Coveralls
         if: matrix.mode == 'gcov' && matrix.config-opt == '--enable-mcsat'
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: 'coverage.info'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,12 +61,12 @@ jobs:
         uses: ./.github/actions/coverage
       - name: Coveralls
         if: matrix.mode == 'gcov' && matrix.config-opt == '--enable-mcsat' && github.ref == 'refs/heads/master'
+        # Best-effort: don't fail CI on a Coveralls outage.
+        continue-on-error: true
         uses: coverallsapp/github-action@v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: 'coverage.info'
-          # A Coveralls outage (e.g. a 502 on upload) must not fail CI.
-          fail-on-error: false
 
   build-pr:
     if: github.event_name == 'pull_request'
@@ -128,9 +128,9 @@ jobs:
         uses: ./.github/actions/coverage
       - name: Coveralls
         if: matrix.mode == 'gcov' && matrix.config-opt == '--enable-mcsat'
+        # Best-effort: don't fail CI on a Coveralls outage.
+        continue-on-error: true
         uses: coverallsapp/github-action@v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: 'coverage.info'
-          # A Coveralls outage (e.g. a 502 on upload) must not fail CI.
-          fail-on-error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: 'coverage.info'
+          # A Coveralls outage (e.g. a 502 on upload) must not fail CI.
+          fail-on-error: false
 
   build-pr:
     if: github.event_name == 'pull_request'
@@ -130,3 +132,5 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: 'coverage.info'
+          # A Coveralls outage (e.g. a 502 on upload) must not fail CI.
+          fail-on-error: false

--- a/.github/workflows/windows_ci.yml
+++ b/.github/workflows/windows_ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - run: git config --global core.autocrlf false && git config --global core.eol lf
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install Cygwin Dependencies
       uses: cygwin/cygwin-install-action@v4


### PR DESCRIPTION
## What

Two CI-workflow hygiene fixes.

1. **Coveralls upload no longer fails CI.** The `gcov`/`--enable-mcsat` job uploads coverage via `coverallsapp/github-action`; a transient Coveralls outage (a `502` on upload) was failing the whole job even though the build and tests passed. Set `fail-on-error: false` on both Coveralls steps so a Coveralls hiccup uploads-when-up but can't red-X CI. **This is the fix for the observed failure.**

2. **Bump actions off the deprecated Node 20 runtime.** `actions/checkout@v4` runs on Node 20 → `@v5` (Node 24). Pin `coverallsapp/github-action` to `@v2.3.6` (a composite action, no Node 20) instead of tracking `@master` unpinned. `cygwin/cygwin-install-action` is already composite, so it's left as-is. This clears the Node 20 deprecation warnings; it was not itself the cause of the failure (GitHub already force-runs those actions on Node 24).

Coverage collection itself is unchanged.