### PR TITLE
Fixed ignored `--mcsat-partial-restarts` option

### DIFF
--- a/src/frontend/smt2/smt2_commands.c
+++ b/src/frontend/smt2/smt2_commands.c
@@ -5242,9 +5242,6 @@ static bool is_yices_option(const char *name, const char **option) {
  * If not supported it simply returns false.
  */
 static bool yices_get_option(smt2_globals_t *g, yices_param_t p) {
-  bool supported;
-
-  supported = true;
 
   switch (p) {
   case PARAM_VAR_ELIM:
@@ -5492,6 +5489,10 @@ static bool yices_get_option(smt2_globals_t *g, yices_param_t p) {
     print_string_value(ematchmode2string[g->ef_client.ef_parameters.ematch_term_mode]);
     break;
 
+  case PARAM_MCSAT_BV_VAR_SIZE:
+    print_int32_value(g->mcsat_options.bv_var_size);
+    break;
+
   case PARAM_MCSAT_L2O:
     print_boolean_value(g->mcsat_options.l2o);
     break;
@@ -5516,6 +5517,10 @@ static bool yices_get_option(smt2_globals_t *g, yices_param_t p) {
     print_boolean_value(g->mcsat_options.na_nlsat);
     break;
 
+  case PARAM_MCSAT_PARTIAL_RESTART:
+    print_boolean_value(g->mcsat_options.partial_restart);
+    break;
+
   case PARAM_MCSAT_RAND_DEC_FREQ:
     print_float_value(g->parameters.randomness);
     break;
@@ -5536,10 +5541,10 @@ static bool yices_get_option(smt2_globals_t *g, yices_param_t p) {
   case PARAM_UNKNOWN:
   default:
     freport_bug(g->err,"invalid parameter id in 'yices_get_option'");
-    break;
+    return false;
   }
 
-  return supported;
+  return true;
 }
 
 /*
@@ -6315,6 +6320,16 @@ static void yices_set_option(smt2_globals_t *g, const char *param, const param_v
       context = g->ctx;
       if (context != NULL) {
         context->mcsat_options.bv_var_size = n;
+      }
+    }
+    break;
+
+  case PARAM_MCSAT_PARTIAL_RESTART:
+    if (param_val_to_bool(param, val, &tt, &reason)) {
+      g->mcsat_options.partial_restart = tt;
+      context = g->ctx;
+      if (context != NULL) {
+        context->mcsat_options.partial_restart = tt;
       }
     }
     break;


### PR DESCRIPTION
Fixed missing wireing of the MCSAT_PARTIAL_RESTART parameter in the front-end.
The parameter was never set and any config (cmdline as well as smt2 setting) was ignored.
Also fixed printing of PARAM_MCSAT_BV_VAR_SIZE.